### PR TITLE
Improve admin page builder editing experience

### DIFF
--- a/sushi-store/AGENTS.md
+++ b/sushi-store/AGENTS.md
@@ -1,0 +1,5 @@
+# Contributor Notes
+- Load and reuse the helpers exported from `client/modules/siteBuilder/core.js` when touching the admin page builder.
+- Keep visual-constructor logic modular: shared registries and utilities live under `client/modules/siteBuilder/`.
+- Prefer extracting reusable styling helpers instead of hardcoding colors and spacings inside templates.
+- Shared preview/style helpers now live in `client/modules/siteBuilder/styles.js`—import from `window.SiteBuilder.styles` rather than redefining them.

--- a/sushi-store/client/index.html
+++ b/sushi-store/client/index.html
@@ -497,9 +497,18 @@
         const modules = [
           '/modules/auth.js',
           '/modules/account.js',
+          '/modules/siteBuilder/elements.js',
+          '/modules/siteBuilder/blocks/hero.js',
+          '/modules/siteBuilder/blocks/categories.js',
+          '/modules/siteBuilder/blocks/menu.js',
+          '/modules/siteBuilder/blocks/delivery.js',
+          '/modules/siteBuilder/blocks/reviews.js',
+          '/modules/siteBuilder/blocks/map.js',
+          '/modules/siteBuilder/styles.js',
+          '/modules/siteBuilder/core.js',
           '/modules/adminSiteSettings.js',
           '/modules/admin.js',
-          '/modules/home.js', 
+          '/modules/home.js',
           '/modules/cartCheckout.js',
           '/modules/floatingCart.js'
         ];
@@ -508,7 +517,7 @@
         
         modules.forEach((src, index) => {
           const script = document.createElement('script');
-          script.src = src + '?v=13';
+          script.src = src + '?v=14';
           script.onload = () => {
             loadedCount++;
             console.log(`Модуль ${src} загружен`);

--- a/sushi-store/client/modules/adminSiteSettings.js
+++ b/sushi-store/client/modules/adminSiteSettings.js
@@ -1,6 +1,6 @@
 // Админ-модуль: Настройки сайта и визуальный конструктор главной страницы
 (function(){
-  const { ref, reactive, computed, watch, onMounted } = Vue;
+  const { ref, reactive, computed, watch, onMounted, onUnmounted, nextTick } = Vue;
 
   const elementRegistry = {
     heading: {
@@ -13,7 +13,22 @@
         color: '#111827',
         align: 'left',
         marginTop: '0px',
-        marginBottom: '16px'
+        marginBottom: '16px',
+        fontFamily: '',
+        fontWeight: '700',
+        lineHeight: '1.2',
+        letterSpacing: '0px',
+        textTransform: 'none',
+        backgroundColor: '',
+        paddingX: '0px',
+        paddingY: '0px',
+        borderRadius: '0px',
+        textShadow: '',
+        positionMode: 'flow',
+        positionX: '0px',
+        positionY: '0px',
+        zIndex: '10',
+        maxWidth: '640px'
       }),
       fields: [
         { key: 'text', label: 'Текст', type: 'text', placeholder: 'Введите заголовок' },
@@ -38,6 +53,32 @@
           ]
         },
         {
+          key: 'fontWeight',
+          label: 'Начертание',
+          type: 'select',
+          options: [
+            { value: '400', label: 'Обычный' },
+            { value: '500', label: 'Средний' },
+            { value: '600', label: 'Полужирный' },
+            { value: '700', label: 'Жирный' },
+            { value: '800', label: 'Экстра жирный' }
+          ]
+        },
+        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Manrope"' },
+        { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.2' },
+        { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
+        {
+          key: 'textTransform',
+          label: 'Регистр',
+          type: 'select',
+          options: [
+            { value: 'none', label: 'Обычный' },
+            { value: 'uppercase', label: 'Верхний' },
+            { value: 'lowercase', label: 'Нижний' },
+            { value: 'capitalize', label: 'Каждое слово' }
+          ]
+        },
+        {
           key: 'color',
           label: 'Цвет текста',
           type: 'color'
@@ -53,7 +94,25 @@
           ]
         },
         { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' }
+        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' },
+        { key: 'backgroundColor', label: 'Фон текста', type: 'color' },
+        { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '0px' },
+        { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '0px' },
+        { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '0px' },
+        { key: 'textShadow', label: 'Тень текста', type: 'text', placeholder: '0 10px 30px rgba(15,23,42,0.35)' },
+        {
+          key: 'positionMode',
+          label: 'Расположение',
+          type: 'select',
+          options: [
+            { value: 'flow', label: 'В потоке' },
+            { value: 'free', label: 'Свободное' }
+          ]
+        },
+        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '10' },
+        { key: 'maxWidth', label: 'Макс. ширина', type: 'text', placeholder: '640px' }
       ]
     },
     subheading: {
@@ -65,7 +124,22 @@
         color: '#f97316',
         align: 'left',
         marginTop: '0px',
-        marginBottom: '12px'
+        marginBottom: '12px',
+        fontFamily: '',
+        fontWeight: '600',
+        lineHeight: '1.4',
+        letterSpacing: '0px',
+        textTransform: 'none',
+        backgroundColor: '',
+        paddingX: '0px',
+        paddingY: '0px',
+        borderRadius: '0px',
+        textShadow: '',
+        positionMode: 'flow',
+        positionX: '0px',
+        positionY: '0px',
+        zIndex: '10',
+        maxWidth: '640px'
       }),
       fields: [
         { key: 'text', label: 'Текст', type: 'text', placeholder: 'Введите подзаголовок' },
@@ -80,6 +154,31 @@
           ]
         },
         {
+          key: 'fontWeight',
+          label: 'Начертание',
+          type: 'select',
+          options: [
+            { value: '400', label: 'Обычный' },
+            { value: '500', label: 'Средний' },
+            { value: '600', label: 'Полужирный' },
+            { value: '700', label: 'Жирный' }
+          ]
+        },
+        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Inter"' },
+        { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.4' },
+        { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
+        {
+          key: 'textTransform',
+          label: 'Регистр',
+          type: 'select',
+          options: [
+            { value: 'none', label: 'Обычный' },
+            { value: 'uppercase', label: 'Верхний' },
+            { value: 'lowercase', label: 'Нижний' },
+            { value: 'capitalize', label: 'Каждое слово' }
+          ]
+        },
+        {
           key: 'color',
           label: 'Цвет текста',
           type: 'color'
@@ -95,7 +194,25 @@
           ]
         },
         { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '12px' }
+        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '12px' },
+        { key: 'backgroundColor', label: 'Фон текста', type: 'color' },
+        { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '0px' },
+        { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '0px' },
+        { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '0px' },
+        { key: 'textShadow', label: 'Тень текста', type: 'text', placeholder: '0 6px 20px rgba(15,23,42,0.25)' },
+        {
+          key: 'positionMode',
+          label: 'Расположение',
+          type: 'select',
+          options: [
+            { value: 'flow', label: 'В потоке' },
+            { value: 'free', label: 'Свободное' }
+          ]
+        },
+        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '10' },
+        { key: 'maxWidth', label: 'Макс. ширина', type: 'text', placeholder: '640px' }
       ]
     },
     paragraph: {
@@ -107,7 +224,22 @@
         color: '#4b5563',
         align: 'left',
         marginTop: '0px',
-        marginBottom: '16px'
+        marginBottom: '16px',
+        fontFamily: '',
+        fontWeight: '400',
+        lineHeight: '1.6',
+        letterSpacing: '0px',
+        textTransform: 'none',
+        maxWidth: '640px',
+        backgroundColor: '',
+        paddingX: '0px',
+        paddingY: '0px',
+        borderRadius: '0px',
+        textShadow: '',
+        positionMode: 'flow',
+        positionX: '0px',
+        positionY: '0px',
+        zIndex: '10'
       }),
       fields: [
         { key: 'text', label: 'Текст', type: 'textarea', rows: 3, placeholder: 'Расскажите подробнее' },
@@ -122,6 +254,32 @@
           ]
         },
         {
+          key: 'fontWeight',
+          label: 'Начертание',
+          type: 'select',
+          options: [
+            { value: '300', label: 'Светлый' },
+            { value: '400', label: 'Обычный' },
+            { value: '500', label: 'Средний' },
+            { value: '600', label: 'Полужирный' }
+          ]
+        },
+        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Rubik"' },
+        { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.6' },
+        { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
+        {
+          key: 'textTransform',
+          label: 'Регистр',
+          type: 'select',
+          options: [
+            { value: 'none', label: 'Обычный' },
+            { value: 'uppercase', label: 'Верхний' },
+            { value: 'lowercase', label: 'Нижний' },
+            { value: 'capitalize', label: 'Каждое слово' }
+          ]
+        },
+        { key: 'maxWidth', label: 'Максимальная ширина', type: 'text', placeholder: '640px' },
+        {
           key: 'color',
           label: 'Цвет текста',
           type: 'color'
@@ -137,7 +295,24 @@
           ]
         },
         { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' }
+        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' },
+        { key: 'backgroundColor', label: 'Фон текста', type: 'color' },
+        { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '0px' },
+        { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '0px' },
+        { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '0px' },
+        { key: 'textShadow', label: 'Тень текста', type: 'text', placeholder: '0 4px 16px rgba(15,23,42,0.15)' },
+        {
+          key: 'positionMode',
+          label: 'Расположение',
+          type: 'select',
+          options: [
+            { value: 'flow', label: 'В потоке' },
+            { value: 'free', label: 'Свободное' }
+          ]
+        },
+        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '10' }
       ]
     },
     button: {
@@ -150,7 +325,25 @@
         href: '',
         align: 'left',
         marginTop: '0px',
-        marginBottom: '0px'
+        marginBottom: '0px',
+        backgroundColor: '#ffffff',
+        textColor: '#dc2626',
+        hoverBackgroundColor: '#f3f4f6',
+        hoverTextColor: '#b91c1c',
+        borderRadius: '9999px',
+        borderWidth: '0px',
+        borderColor: '#ffffff',
+        paddingX: '28px',
+        paddingY: '14px',
+        fontSize: '16px',
+        fontFamily: '',
+        fontWeight: '600',
+        boxShadow: '0 15px 40px rgba(255,255,255,0.18)',
+        positionMode: 'flow',
+        positionX: '0px',
+        positionY: '0px',
+        zIndex: '20',
+        width: ''
       }),
       fields: [
         { key: 'text', label: 'Текст кнопки', type: 'text', placeholder: 'Например, Заказать' },
@@ -174,6 +367,18 @@
           ]
         },
         { key: 'href', label: 'Ссылка', type: 'text', placeholder: 'https://...' },
+        { key: 'fontSize', label: 'Размер шрифта (px)', type: 'text', placeholder: '16px' },
+        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Nunito"' },
+        {
+          key: 'fontWeight',
+          label: 'Начертание',
+          type: 'select',
+          options: [
+            { value: '500', label: 'Средний' },
+            { value: '600', label: 'Полужирный' },
+            { value: '700', label: 'Жирный' }
+          ]
+        },
         {
           key: 'align',
           label: 'Выравнивание',
@@ -185,7 +390,30 @@
           ]
         },
         { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '0px' }
+        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '0px' },
+        { key: 'backgroundColor', label: 'Цвет фона', type: 'color' },
+        { key: 'textColor', label: 'Цвет текста', type: 'color' },
+        { key: 'hoverBackgroundColor', label: 'Фон при наведении', type: 'color' },
+        { key: 'hoverTextColor', label: 'Текст при наведении', type: 'color' },
+        { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '9999px' },
+        { key: 'borderWidth', label: 'Толщина границы', type: 'text', placeholder: '0px' },
+        { key: 'borderColor', label: 'Цвет границы', type: 'color' },
+        { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '28px' },
+        { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '14px' },
+        { key: 'boxShadow', label: 'Тень', type: 'text', placeholder: '0 15px 40px rgba(255,255,255,0.18)' },
+        {
+          key: 'positionMode',
+          label: 'Расположение',
+          type: 'select',
+          options: [
+            { value: 'flow', label: 'В потоке' },
+            { value: 'free', label: 'Свободное' }
+          ]
+        },
+        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '20' },
+        { key: 'width', label: 'Ширина', type: 'text', placeholder: 'auto' }
       ]
     },
     image: {
@@ -199,7 +427,16 @@
         align: 'left',
         borderRadius: '16px',
         marginTop: '0px',
-        marginBottom: '16px'
+        marginBottom: '16px',
+        objectFit: 'cover',
+        boxShadow: '0 25px 60px rgba(15,23,42,0.35)',
+        borderWidth: '0px',
+        borderColor: 'rgba(255,255,255,0.2)',
+        backgroundColor: 'transparent',
+        positionMode: 'flow',
+        positionX: '0px',
+        positionY: '0px',
+        zIndex: '5'
       }),
       fields: [
         { key: 'src', label: 'URL изображения', type: 'text', placeholder: 'https://...' },
@@ -218,7 +455,33 @@
         },
         { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '16px' },
         { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' }
+        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' },
+        {
+          key: 'objectFit',
+          label: 'Вписывание',
+          type: 'select',
+          options: [
+            { value: 'cover', label: 'Cover' },
+            { value: 'contain', label: 'Contain' },
+            { value: 'fill', label: 'Fill' }
+          ]
+        },
+        { key: 'boxShadow', label: 'Тень', type: 'text', placeholder: '0 25px 60px rgba(15,23,42,0.35)' },
+        { key: 'borderWidth', label: 'Толщина границы', type: 'text', placeholder: '0px' },
+        { key: 'borderColor', label: 'Цвет границы', type: 'color' },
+        { key: 'backgroundColor', label: 'Фон', type: 'color' },
+        {
+          key: 'positionMode',
+          label: 'Расположение',
+          type: 'select',
+          options: [
+            { value: 'flow', label: 'В потоке' },
+            { value: 'free', label: 'Свободное' }
+          ]
+        },
+        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '5' }
       ]
     },
     feature: {
@@ -230,11 +493,34 @@
         color: '#111827',
         fontSize: 'text-base',
         marginTop: '0px',
-        marginBottom: '8px'
+        marginBottom: '8px',
+        fontFamily: '',
+        fontWeight: '500',
+        lineHeight: '1.4',
+        letterSpacing: '0px',
+        textTransform: 'none',
+        iconColor: '#f97316',
+        iconBackground: 'rgba(249, 115, 22, 0.12)',
+        iconShape: 'circle',
+        positionMode: 'flow',
+        positionX: '0px',
+        positionY: '0px',
+        zIndex: '15'
       }),
       fields: [
         { key: 'text', label: 'Текст', type: 'text', placeholder: 'Например, Бесплатная доставка' },
         { key: 'icon', label: 'Иконка FontAwesome', type: 'text', placeholder: 'fa-solid fa-check' },
+        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Open Sans"' },
+        {
+          key: 'fontWeight',
+          label: 'Начертание',
+          type: 'select',
+          options: [
+            { value: '400', label: 'Обычный' },
+            { value: '500', label: 'Средний' },
+            { value: '600', label: 'Полужирный' }
+          ]
+        },
         {
           key: 'color',
           label: 'Цвет текста',
@@ -250,8 +536,44 @@
             { value: 'text-lg', label: 'Крупный' }
           ]
         },
+        { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.4' },
+        { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
+        {
+          key: 'textTransform',
+          label: 'Регистр',
+          type: 'select',
+          options: [
+            { value: 'none', label: 'Обычный' },
+            { value: 'uppercase', label: 'Верхний' },
+            { value: 'capitalize', label: 'Каждое слово' }
+          ]
+        },
+        { key: 'iconColor', label: 'Цвет иконки', type: 'color' },
+        { key: 'iconBackground', label: 'Фон иконки', type: 'color' },
+        {
+          key: 'iconShape',
+          label: 'Форма иконки',
+          type: 'select',
+          options: [
+            { value: 'circle', label: 'Круг' },
+            { value: 'rounded', label: 'Скруглённый квадрат' },
+            { value: 'square', label: 'Квадрат' }
+          ]
+        },
         { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '8px' }
+        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '8px' },
+        {
+          key: 'positionMode',
+          label: 'Расположение',
+          type: 'select',
+          options: [
+            { value: 'flow', label: 'В потоке' },
+            { value: 'free', label: 'Свободное' }
+          ]
+        },
+        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '15' }
       ]
     },
     spacer: {
@@ -289,6 +611,17 @@
         waveEnabled: true,
         waveColor: '#f9f4e5',
         overlayColor: 'rgba(17, 24, 39, 0.55)',
+        contentMaxWidth: '620px',
+        contentPaddingX: '96px',
+        contentPaddingY: '120px',
+        contentGap: '40px',
+        minHeight: '640px',
+        freeformHeight: '640px',
+        layout: 'split',
+        backgroundPosition: 'center center',
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+        overlayBlur: '0',
         elements: [
           {
             type: 'heading',
@@ -373,6 +706,28 @@
           ]
         },
         {
+          label: 'Макет',
+          fields: [
+            {
+              key: 'layout',
+              label: 'Расположение',
+              type: 'select',
+              options: [
+                { value: 'split', label: 'Текст и изображение' },
+                { value: 'stacked', label: 'Только текст' },
+                { value: 'spotlight', label: 'Текст над изображением' },
+                { value: 'freeform', label: 'Свободное расположение' }
+              ]
+            },
+            { key: 'contentMaxWidth', label: 'Ширина контента', type: 'text', placeholder: '620px' },
+            { key: 'contentPaddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '96px' },
+            { key: 'contentPaddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '120px' },
+            { key: 'contentGap', label: 'Отступ между колонками', type: 'text', placeholder: '40px' },
+            { key: 'minHeight', label: 'Минимальная высота', type: 'text', placeholder: '640px' },
+            { key: 'freeformHeight', label: 'Высота для свободного режима', type: 'text', placeholder: '640px' }
+          ]
+        },
+        {
           label: 'Оформление',
           fields: [
             { key: 'backgroundImage', label: 'Фоновое изображение', type: 'image' },
@@ -389,7 +744,11 @@
             { key: 'showRightImage', label: 'Показывать изображение', type: 'toggle' },
             { key: 'waveEnabled', label: 'Декоративная волна', type: 'toggle' },
             { key: 'waveColor', label: 'Цвет волны', type: 'color' },
-            { key: 'overlayColor', label: 'Цвет наложения', type: 'color' }
+            { key: 'overlayColor', label: 'Цвет наложения', type: 'color' },
+            { key: 'backgroundPosition', label: 'Позиция фона', type: 'text', placeholder: 'center center' },
+            { key: 'backgroundSize', label: 'Размер фона', type: 'text', placeholder: 'cover' },
+            { key: 'backgroundRepeat', label: 'Повторение фона', type: 'text', placeholder: 'no-repeat' },
+            { key: 'overlayBlur', label: 'Размытие наложения (px)', type: 'text', placeholder: '0' }
           ]
         }
       ],
@@ -886,13 +1245,31 @@
               </div>
 
               <div
+                ref="canvasViewportRef"
                 class="relative border border-gray-200 rounded-2xl bg-gray-50"
                 :class="canvas.mode === 'full' ? 'overflow-auto max-h-[calc(100vh-320px)]' : 'overflow-hidden'"
+                @scroll="onCanvasScroll"
               >
                 <div class="absolute inset-0 pointer-events-none bg-[radial-gradient(circle,_rgba(148,163,184,0.12)_1px,_transparent_1px)] bg-[length:16px_16px]" v-if="canvas.showGrid"></div>
                 <div
+                  v-if="canvas.showOverlays && selectionOverlay.visible"
+                  class="absolute z-20 pointer-events-none"
+                  :style="selectionOverlayStyle"
+                >
+                  <div class="absolute inset-0 border-2 border-orange-400 rounded-2xl shadow-[0_0_0_1px_rgba(255,255,255,0.35)]"></div>
+                  <div
+                    class="absolute left-0 bg-orange-500 text-white text-xs font-semibold px-3 py-1 rounded-full shadow"
+                    :class="selectionOverlay.badgeBelow ? 'top-full mt-2' : '-top-8'"
+                  >
+                    {{ selectionOverlay.label }}
+                    <span class="uppercase tracking-wider text-white/70 ml-2">{{ selectionOverlay.type === 'element' ? 'Элемент' : 'Блок' }}</span>
+                  </div>
+                </div>
+                <div
                   class="relative origin-top transition-all duration-300 ease-out"
+                  ref="canvasInnerRef"
                   :style="canvasStyle"
+                  @click="handleCanvasClick"
                 >
                   <div class="bg-white min-h-[640px]" :style="{ backgroundColor: form.background_color || '#ffffff' }">
                     <div
@@ -918,11 +1295,13 @@
                         </div>
 
                         <section
-                          @click.stop="selectBlock(block.id)"
+                          @click="handleBlockClick(block.id, $event)"
                           :class="[
                             blockWrapperClasses(block),
                             block.meta.hidden ? 'opacity-60' : 'opacity-100'
                           ]"
+                          :ref="el => registerBlockRef(block.id, el)"
+                          :data-block-id="block.id"
                         >
                           <div
                             v-if="canvas.showOverlays"
@@ -931,15 +1310,17 @@
                           ></div>
 
                           <template v-if="block.type === 'hero'">
-                            <div class="relative overflow-hidden rounded-3xl text-white">
-                              <img
-                                :src="block.data.backgroundImage"
-                                alt="hero bg"
-                                class="absolute inset-0 w-full h-full object-cover"
-                              />
-                              <div class="absolute inset-0" :style="{ background: block.data.overlayColor || 'rgba(17,24,39,0.6)' }"></div>
-                              <div class="relative grid lg:grid-cols-2 gap-12 px-12 py-16">
-                                <div class="space-y-4">
+                            <div
+                              class="relative overflow-hidden rounded-3xl text-white shadow-xl"
+                              :style="heroWrapperStyle(block)"
+                            >
+                              <div class="absolute inset-0" :style="heroBackgroundStyle(block)"></div>
+                              <div class="absolute inset-0" :style="heroOverlayStyle(block)"></div>
+                              <div :class="heroContainerClasses(block)" :style="heroContainerStyle(block)">
+                                <div
+                                  :class="heroContentColumnClasses(block)"
+                                  :style="heroContentStyle(block)"
+                                >
                                   <div
                                     v-if="!block.data.elements || !block.data.elements.length"
                                     class="border border-dashed border-white/40 rounded-2xl px-4 py-6 text-sm text-white/70 text-center"
@@ -950,9 +1331,10 @@
                                     <div
                                       v-for="(element, elementIndex) in block.data.elements"
                                       :key="element.id"
-                                      class="space-y-2"
+                                      :class="block.data.layout === 'freeform' ? '' : 'space-y-2'"
                                     >
                                       <div
+                                        v-if="block.data.layout !== 'freeform'"
                                         class="flex justify-center h-8 transition"
                                         @dragover.prevent="onHeroElementDragOver(block.id, elementIndex)"
                                         @dragenter.prevent="onHeroElementDragOver(block.id, elementIndex)"
@@ -968,24 +1350,32 @@
                                         </div>
                                       </div>
                                       <div
-                                        :class="heroElementWrapperClasses(block.id, element)"
-                                        draggable="true"
+                                        :class="heroElementWrapperClasses(block, element)"
+                                        :style="heroElementWrapperStyle(block, element)"
+                                        :draggable="heroElementDraggable(block, element)"
                                         @dragstart="onHeroElementDragStart(block.id, element.id, $event)"
                                         @dragend="onHeroElementDragEnd"
-                                        @click.stop="selectElement(block.id, element.id)"
+                                        @pointerdown="onHeroElementPointerDown(block.id, element.id, $event)"
+                                        @click="handleElementClick(block.id, element.id, $event)"
+                                        :ref="el => registerElementRef(block.id, element.id, el)"
+                                        :data-element-id="element.id"
+                                        :data-block-id="block.id"
                                       >
                                         <div
                                           v-if="canvas.showOverlays"
                                           class="absolute inset-0 rounded-2xl border border-dashed border-white/30 pointer-events-none"
                                           :class="isElementSelected(element) && selectedBlockId === block.id ? 'border-orange-300' : ''"
                                         ></div>
-                                        <div class="absolute -left-5 top-1/2 -translate-y-1/2 hidden group-hover:flex flex-col items-center space-y-1 text-white/70">
+                                        <div
+                                          v-if="heroElementDraggable(block, element)"
+                                          class="absolute -left-5 top-1/2 -translate-y-1/2 hidden group-hover:flex flex-col items-center space-y-1 text-white/70"
+                                        >
                                           <span class="cursor-grab text-xs"><i class="fa-solid fa-grip-vertical"></i></span>
                                         </div>
                                         <div class="absolute top-2 right-2 text-[11px] uppercase tracking-wider text-white/80 bg-black/30 px-2 py-1 rounded-full">{{ elementRegistry[element.type]?.label || element.type }}</div>
                                         <component
                                           :is="renderHeroElement(element)"
-                                          v-bind="heroElementProps(element)"
+                                          v-bind="heroElementProps(block, element)"
                                         >
                                           <template v-if="element.type === 'button'">
                                             <span>{{ element.data.text }}</span>
@@ -999,12 +1389,22 @@
                                               :style="heroImageProps(element).style"
                                             />
                                           </template>
+                                          <template v-else-if="element.type === 'feature'">
+                                            <span
+                                              class="inline-flex items-center justify-center h-12 w-12 text-lg"
+                                              :style="heroFeatureIconWrapperStyle(element)"
+                                            >
+                                              <i :class="element.data.icon || 'fa-solid fa-check'"></i>
+                                            </span>
+                                            <span>{{ element.data.text }}</span>
+                                          </template>
                                           <template v-else-if="element.type === 'spacer'"></template>
                                           <template v-else>{{ element.data.text }}</template>
                                         </component>
                                       </div>
                                     </div>
                                     <div
+                                      v-if="block.data.layout !== 'freeform'"
                                       class="flex justify-center h-8 transition mt-2"
                                       @dragover.prevent="onHeroElementDragOver(block.id, block.data.elements.length)"
                                       @dragenter.prevent="onHeroElementDragOver(block.id, block.data.elements.length)"
@@ -1021,8 +1421,8 @@
                                     </div>
                                   </template>
                                 </div>
-                                <div class="hidden lg:flex items-center justify-center">
-                                  <div v-if="block.data.showRightImage" class="relative">
+                                <div v-if="block.data.showRightImage" :class="heroMediaWrapperClasses(block)">
+                                  <div class="relative">
                                     <img :src="block.data.previewImage" alt="preview" class="w-80 h-80 object-cover rounded-3xl shadow-2xl" />
                                     <div class="absolute inset-0 rounded-3xl ring-4 ring-white/20"></div>
                                   </div>
@@ -1453,11 +1853,40 @@
         dropIndex: null,
         targetBlockId: null
       });
+      const freeformDrag = reactive({
+        active: false,
+        blockId: null,
+        elementId: null,
+        startX: 0,
+        startY: 0,
+        originX: 0,
+        originY: 0,
+        containerWidth: 0,
+        containerHeight: 0,
+        elementWidth: 0,
+        elementHeight: 0
+      });
+
+      const canvasViewportRef = ref(null);
+      const canvasInnerRef = ref(null);
+      const blockRefs = new Map();
+      const elementRefs = new Map();
+
+      const selectionOverlay = reactive({
+        visible: false,
+        top: 0,
+        left: 0,
+        width: 0,
+        height: 0,
+        label: '',
+        type: 'block',
+        badgeBelow: false
+      });
 
       const canvas = reactive({
         device: 'desktop',
-        zoom: 0.85,
-        mode: 'preview',
+        zoom: 1,
+        mode: 'full',
         showGrid: false,
         showOverlays: true
       });
@@ -1531,6 +1960,13 @@
 
       const currentElementDefinition = computed(() => currentElement.value ? (elementRegistry[currentElement.value.type] || { fields: [] }) : { fields: [] });
 
+      const selectionOverlayStyle = computed(() => ({
+        top: selectionOverlay.top + 'px',
+        left: selectionOverlay.left + 'px',
+        width: selectionOverlay.width + 'px',
+        height: selectionOverlay.height + 'px'
+      }));
+
       function blockWrapperClasses(block) {
         return [
           'relative transition-all duration-300 cursor-pointer rounded-3xl overflow-hidden',
@@ -1552,66 +1988,129 @@
           case 'spacer':
             return 'div';
           case 'feature':
-            return 'p';
+            return 'div';
           default:
             return 'div';
         }
       }
 
-      function heroElementProps(element) {
+      function heroElementProps(block, element) {
         const data = element.data || {};
         const classes = [];
         const style = {};
+        const events = {};
+        const freePositioned = elementUsesFreePosition(block, element);
 
         if (['heading', 'subheading', 'paragraph', 'feature'].includes(element.type)) {
           classes.push(data.fontSize || (element.type === 'heading' ? 'text-4xl' : element.type === 'subheading' ? 'text-xl' : 'text-base'));
-          if (element.type === 'heading' || element.type === 'feature') {
-            classes.push('font-bold');
-          } else {
-            classes.push('font-medium');
-          }
+          style.fontWeight = data.fontWeight || (element.type === 'heading' ? '700' : element.type === 'feature' ? '600' : '500');
+          if (data.fontFamily) style.fontFamily = data.fontFamily;
+          if (data.lineHeight) style.lineHeight = data.lineHeight;
+          if (data.letterSpacing) style.letterSpacing = asCssSize(data.letterSpacing, '0px');
+          if (data.textTransform && data.textTransform !== 'none') style.textTransform = data.textTransform;
+          if (data.maxWidth) style.maxWidth = asCssSize(data.maxWidth, '640px');
           if (data.align === 'center') classes.push('text-center');
           else if (data.align === 'right') classes.push('text-right');
           else classes.push('text-left');
           style.color = data.color || (element.type === 'subheading' ? '#fbbf24' : '#ffffff');
-          style.marginTop = data.marginTop || '0px';
-          style.marginBottom = data.marginBottom || '16px';
+          style.marginTop = freePositioned ? '0px' : asCssSize(data.marginTop, '0px');
+          const marginFallback = element.type === 'subheading' ? '12px' : element.type === 'feature' ? '8px' : '16px';
+          style.marginBottom = freePositioned ? '0px' : asCssSize(data.marginBottom, marginFallback);
+          if (data.backgroundColor) {
+            style.backgroundColor = data.backgroundColor;
+            style.display = element.type === 'feature' ? 'inline-flex' : 'inline-block';
+            style.padding = `${asCssSize(data.paddingY, '0px')} ${asCssSize(data.paddingX, '0px')}`;
+            style.borderRadius = asCssSize(data.borderRadius, '0px');
+          }
+          if (data.textShadow) {
+            style.textShadow = data.textShadow;
+          }
+          if (element.type === 'feature') {
+            classes.push('flex items-center space-x-3');
+          }
         }
 
         if (element.type === 'button') {
-          classes.push('px-6 py-3 rounded-full font-semibold inline-flex items-center transition shadow');
-          if (data.style === 'secondary') {
-            classes.push('bg-transparent border-2 border-white text-white hover:bg-white hover:text-red-600');
-          } else {
-            classes.push('bg-white text-red-600 hover:bg-gray-100');
+          classes.push('inline-flex items-center justify-center transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/40');
+          if (!freePositioned) {
+            if (data.align === 'center') classes.push('mx-auto');
+            else if (data.align === 'right') classes.push('ml-auto');
           }
-          if (data.align === 'center') classes.push('mx-auto');
-          else if (data.align === 'right') classes.push('ml-auto');
-          else classes.push('mr-auto');
-          style.marginTop = data.marginTop || '0px';
-          style.marginBottom = data.marginBottom || '0px';
+          style.marginTop = freePositioned ? '0px' : asCssSize(data.marginTop, '0px');
+          style.marginBottom = freePositioned ? '0px' : asCssSize(data.marginBottom, '0px');
+          style.paddingLeft = asCssSize(data.paddingX, '28px');
+          style.paddingRight = asCssSize(data.paddingX, '28px');
+          style.paddingTop = asCssSize(data.paddingY, '14px');
+          style.paddingBottom = asCssSize(data.paddingY, '14px');
+          style.borderRadius = asCssSize(data.borderRadius, '9999px');
+          style.borderWidth = asCssSize(data.borderWidth, data.style === 'secondary' ? '2px' : '0px');
+          style.borderStyle = 'solid';
+          style.borderColor = data.borderColor || '#ffffff';
+          style.backgroundColor = data.backgroundColor || (data.style === 'secondary' ? 'transparent' : '#ffffff');
+          style.color = data.textColor || (data.style === 'secondary' ? '#ffffff' : '#dc2626');
+          style.boxShadow = data.boxShadow || '0 15px 40px rgba(255,255,255,0.18)';
+          style.fontSize = asCssSize(data.fontSize, '16px');
+          style.fontFamily = data.fontFamily || 'inherit';
+          style.fontWeight = data.fontWeight || '600';
+          style.transition = 'all 0.25s ease';
+          if (data.width) {
+            style.width = asCssSize(data.width, 'auto');
+          }
+
+          const hoverBackground = data.hoverBackgroundColor || (data.style === 'secondary' ? '#ffffff' : '#f3f4f6');
+          const hoverColor = data.hoverTextColor || (data.style === 'secondary' ? (data.textColor || '#1f2937') : '#b91c1c');
+          events.onMouseenter = (event) => {
+            event.target.dataset.prevBg = event.target.style.backgroundColor;
+            event.target.dataset.prevColor = event.target.style.color;
+            event.target.style.backgroundColor = hoverBackground;
+            event.target.style.color = hoverColor;
+          };
+          events.onMouseleave = (event) => {
+            if (event.target.dataset.prevBg) {
+              event.target.style.backgroundColor = event.target.dataset.prevBg;
+            }
+            if (event.target.dataset.prevColor) {
+              event.target.style.color = event.target.dataset.prevColor;
+            }
+          };
         }
 
         if (element.type === 'image') {
-          if (data.align === 'center') classes.push('text-center');
-          else if (data.align === 'right') classes.push('text-right');
-          else classes.push('text-left');
-          style.marginTop = data.marginTop || '0px';
-          style.marginBottom = data.marginBottom || '16px';
+          if (!freePositioned) {
+            if (data.align === 'center') classes.push('text-center');
+            else if (data.align === 'right') classes.push('text-right');
+            else classes.push('text-left');
+          }
+          style.marginTop = freePositioned ? '0px' : asCssSize(data.marginTop, '0px');
+          style.marginBottom = freePositioned ? '0px' : asCssSize(data.marginBottom, '16px');
+          if (!freePositioned) {
+            if (data.align === 'center') {
+              style.display = 'flex';
+              style.justifyContent = 'center';
+            } else if (data.align === 'right') {
+              style.display = 'flex';
+              style.justifyContent = 'flex-end';
+            }
+          }
         }
 
         if (element.type === 'spacer') {
-          style.height = data.height || '24px';
+          style.height = asCssSize(data.height, '24px');
           classes.push('w-full');
+          if (freePositioned) {
+            style.marginTop = '0px';
+            style.marginBottom = '0px';
+          }
         }
 
         if (element.type === 'feature') {
-          classes.push('flex items-center space-x-2');
+          classes.push('flex items-center space-x-3');
         }
 
         return {
           class: classes.join(' '),
-          style
+          style,
+          ...events
         };
       }
 
@@ -1621,9 +2120,15 @@
           src: data.src || 'https://images.unsplash.com/photo-1607301405418-780ee5e6dd10',
           alt: data.alt || 'Изображение',
           style: {
-            width: data.width || '320px',
-            height: data.height || 'auto',
-            borderRadius: data.borderRadius || '16px'
+            width: asCssSize(data.width, '320px'),
+            height: data.height ? asCssSize(data.height, 'auto') : 'auto',
+            borderRadius: asCssSize(data.borderRadius, '16px'),
+            objectFit: data.objectFit || 'cover',
+            boxShadow: data.boxShadow || '0 25px 60px rgba(15,23,42,0.35)',
+            borderWidth: asCssSize(data.borderWidth, '0px'),
+            borderStyle: 'solid',
+            borderColor: data.borderColor || 'rgba(255,255,255,0.2)',
+            backgroundColor: data.backgroundColor || 'transparent'
           }
         };
       }
@@ -1790,11 +2295,19 @@
       }
 
       function heroDropIsActive(blockId, index) {
-        return Boolean(heroDrag.elementId) && heroDrag.targetBlockId === blockId && heroDrag.dropIndex === index;
+        if (!heroDrag.elementId) {
+          return false;
+        }
+        const block = getBlockById(blockId);
+        if (!block || isFreeformBlock(block)) {
+          return false;
+        }
+        return heroDrag.targetBlockId === blockId && heroDrag.dropIndex === index;
       }
 
       function heroDropWrapperClass(blockId, index) {
-        if (!heroDrag.elementId) {
+        const block = getBlockById(blockId);
+        if (!heroDrag.elementId || isFreeformBlock(block)) {
           return 'opacity-0 pointer-events-auto';
         }
         return heroDropIsActive(blockId, index)
@@ -1808,17 +2321,441 @@
           : 'border-white/40 text-white/70 bg-black/20';
       }
 
-      function heroElementWrapperClasses(blockId, element) {
-        const classes = ['relative group rounded-2xl px-2 py-1 transition hover:bg-white/10 hover:bg-opacity-30'];
-        if (selectedBlockId.value === blockId && isElementSelected(element)) {
-          classes.push('ring-2 ring-orange-300 bg-white/10 shadow-lg');
+      function heroElementWrapperClasses(block, element) {
+        const classes = ['relative group transition'];
+        const isSelected = selectedBlockId.value === block?.id && isElementSelected(element);
+        if (isSelected) {
+          classes.push('ring-2 ring-orange-300 shadow-lg backdrop-blur-sm');
         } else {
-          classes.push('ring-1 ring-transparent hover:ring-white/40');
+          classes.push('ring-1 ring-transparent');
+        }
+        if (elementUsesFreePosition(block, element)) {
+          classes.push('cursor-move select-none pointer-events-auto');
+        } else {
+          classes.push('rounded-2xl px-2 py-1 hover:bg-white/10 hover:bg-opacity-30 hover:ring-white/40');
         }
         return classes.join(' ');
       }
 
+      function heroElementWrapperStyle(block, element) {
+        const style = {};
+        if (!block || !element) {
+          return style;
+        }
+        const data = element.data || {};
+        if (elementUsesFreePosition(block, element)) {
+          style.position = 'absolute';
+          style.left = asCssSize(data.positionX, '0px');
+          style.top = asCssSize(data.positionY, '0px');
+          style.zIndex = parseCssNumber(data.zIndex, 10);
+          style.userSelect = 'none';
+          if (data.width) {
+            style.width = asCssSize(data.width, 'auto');
+          }
+          if (data.maxWidth) {
+            style.maxWidth = asCssSize(data.maxWidth, 'auto');
+          }
+        } else {
+          style.position = 'relative';
+        }
+        return style;
+      }
+
+      function heroElementDraggable(block, element) {
+        if (!block || !element) {
+          return false;
+        }
+        if (isFreeformBlock(block)) {
+          return false;
+        }
+        return element.data?.positionMode !== 'free';
+      }
+
+      function handleElementClick(blockId, elementId, event = null) {
+        if (event) {
+          event.stopPropagation();
+        }
+        selectBlock(blockId);
+        currentElementId.value = elementId;
+        elementPaletteOpen.value = false;
+        nextTick(scheduleSelectionOverlay);
+      }
+
+      function handleBlockClick(blockId, event = null) {
+        if (event && event.target && event.target.closest('[data-element-id]')) {
+          return;
+        }
+        selectBlock(blockId);
+        nextTick(scheduleSelectionOverlay);
+      }
+
+      function handleCanvasClick(event) {
+        if (event.target && event.target.closest('[data-block-id]')) {
+          return;
+        }
+        selectedBlockId.value = null;
+        currentElementId.value = null;
+        elementPaletteOpen.value = false;
+        selectionOverlay.visible = false;
+      }
+
+      function onHeroElementPointerDown(blockId, elementId, event) {
+        if (!event || event.button !== 0) {
+          return;
+        }
+        const block = getBlockById(blockId);
+        const element = block?.data?.elements?.find(el => el.id === elementId) || null;
+        if (!block || !element || !elementUsesFreePosition(block, element)) {
+          return;
+        }
+        const wrapper = elementRefs.get(getElementKey(blockId, elementId));
+        if (!wrapper) {
+          return;
+        }
+        const container = wrapper.offsetParent;
+        if (!container) {
+          return;
+        }
+        freeformDrag.active = true;
+        freeformDrag.blockId = blockId;
+        freeformDrag.elementId = elementId;
+        freeformDrag.startX = event.clientX;
+        freeformDrag.startY = event.clientY;
+        freeformDrag.originX = parseCssNumber(element.data.positionX, wrapper.offsetLeft);
+        freeformDrag.originY = parseCssNumber(element.data.positionY, wrapper.offsetTop);
+        freeformDrag.containerWidth = container.clientWidth;
+        freeformDrag.containerHeight = container.clientHeight;
+        freeformDrag.elementWidth = wrapper.clientWidth;
+        freeformDrag.elementHeight = wrapper.clientHeight;
+        selectBlock(blockId);
+        currentElementId.value = elementId;
+        elementPaletteOpen.value = false;
+        window.addEventListener('pointermove', onFreeformPointerMove);
+        window.addEventListener('pointerup', onFreeformPointerUp);
+        event.stopPropagation();
+        event.preventDefault();
+      }
+
+      function onFreeformPointerMove(event) {
+        if (!freeformDrag.active) {
+          return;
+        }
+        const block = getBlockById(freeformDrag.blockId);
+        const element = block?.data?.elements?.find(el => el.id === freeformDrag.elementId) || null;
+        if (!block || !element || !elementUsesFreePosition(block, element)) {
+          onFreeformPointerUp();
+          return;
+        }
+        const zoom = canvas.mode === 'full' ? 1 : canvas.zoom;
+        const deltaX = (event.clientX - freeformDrag.startX) / zoom;
+        const deltaY = (event.clientY - freeformDrag.startY) / zoom;
+        const maxX = Math.max(0, freeformDrag.containerWidth - freeformDrag.elementWidth);
+        const maxY = Math.max(0, freeformDrag.containerHeight - freeformDrag.elementHeight);
+        const nextX = clampNumber(freeformDrag.originX + deltaX, 0, maxX || 0);
+        const nextY = clampNumber(freeformDrag.originY + deltaY, 0, maxY || 0);
+        element.data.positionX = `${Math.round(nextX)}px`;
+        element.data.positionY = `${Math.round(nextY)}px`;
+        scheduleSelectionOverlay();
+      }
+
+      function onFreeformPointerUp() {
+        if (!freeformDrag.active) {
+          return;
+        }
+        freeformDrag.active = false;
+        freeformDrag.blockId = null;
+        freeformDrag.elementId = null;
+        window.removeEventListener('pointermove', onFreeformPointerMove);
+        window.removeEventListener('pointerup', onFreeformPointerUp);
+        nextTick(scheduleSelectionOverlay);
+      }
+
+      function asCssSize(value, fallback) {
+        if (value === null || value === undefined) {
+          return fallback;
+        }
+        const trimmed = String(value).trim();
+        if (!trimmed) {
+          return fallback;
+        }
+        if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+          return `${trimmed}px`;
+        }
+        return trimmed;
+      }
+
+      function parseCssNumber(value, fallback = 0) {
+        if (value === null || value === undefined) {
+          return fallback;
+        }
+        const match = String(value).match(/-?\d+(\.\d+)?/);
+        return match ? Number(match[0]) : fallback;
+      }
+
+      function clampNumber(value, min, max) {
+        if (!Number.isFinite(value)) {
+          return min;
+        }
+        if (value < min) {
+          return min;
+        }
+        if (value > max) {
+          return max;
+        }
+        return value;
+      }
+
+      function getElementKey(blockId, elementId) {
+        return `${blockId}:${elementId}`;
+      }
+
+      function registerBlockRef(blockId, el) {
+        if (el) {
+          blockRefs.set(blockId, el);
+        } else {
+          blockRefs.delete(blockId);
+        }
+        scheduleSelectionOverlay();
+      }
+
+      function registerElementRef(blockId, elementId, el) {
+        const key = getElementKey(blockId, elementId);
+        if (el) {
+          elementRefs.set(key, el);
+        } else {
+          elementRefs.delete(key);
+        }
+        scheduleSelectionOverlay();
+      }
+
+      function getBlockById(blockId) {
+        return pageBlocks.value.find(block => block.id === blockId) || null;
+      }
+
+      function isFreeformBlock(block) {
+        return Boolean(block?.data?.layout === 'freeform');
+      }
+
+      function elementUsesFreePosition(block, element) {
+        return isFreeformBlock(block) && element?.data?.positionMode === 'free';
+      }
+
+      let overlayRaf = null;
+
+      function scheduleSelectionOverlay() {
+        if (overlayRaf) {
+          cancelAnimationFrame(overlayRaf);
+        }
+        overlayRaf = requestAnimationFrame(() => {
+          overlayRaf = null;
+          updateSelectionOverlay();
+        });
+      }
+
+      function updateSelectionOverlay() {
+        if (!canvas.showOverlays) {
+          selectionOverlay.visible = false;
+          return;
+        }
+        const viewportEl = canvasViewportRef.value;
+        if (!viewportEl) {
+          selectionOverlay.visible = false;
+          return;
+        }
+        let targetEl = null;
+        if (currentElementId.value && selectedBlockId.value) {
+          targetEl = elementRefs.get(getElementKey(selectedBlockId.value, currentElementId.value)) || null;
+        }
+        if (!targetEl && selectedBlockId.value) {
+          targetEl = blockRefs.get(selectedBlockId.value) || null;
+        }
+        if (!targetEl) {
+          selectionOverlay.visible = false;
+          return;
+        }
+
+        const viewportRect = viewportEl.getBoundingClientRect();
+        const targetRect = targetEl.getBoundingClientRect();
+        const top = targetRect.top - viewportRect.top + viewportEl.scrollTop;
+        const left = targetRect.left - viewportRect.left + viewportEl.scrollLeft;
+
+        selectionOverlay.top = top;
+        selectionOverlay.left = left;
+        selectionOverlay.width = targetRect.width;
+        selectionOverlay.height = targetRect.height;
+        selectionOverlay.visible = true;
+        selectionOverlay.type = currentElementId.value ? 'element' : 'block';
+        selectionOverlay.label = currentElementId.value
+          ? (elementRegistry[currentElement.value?.type]?.label || currentElement.value?.type || 'Элемент')
+          : (selectedBlock.value?.name || selectedBlock.value?.type || 'Блок');
+        selectionOverlay.badgeBelow = top < 32;
+      }
+
+      function onCanvasScroll() {
+        if (!canvas.showOverlays) return;
+        scheduleSelectionOverlay();
+      }
+
+      function heroWrapperStyle(block) {
+        const data = block.data || {};
+        const layout = data.layout || 'split';
+        const heightValue = layout === 'freeform'
+          ? asCssSize(data.freeformHeight || data.minHeight, '640px')
+          : asCssSize(data.minHeight, '560px');
+        return {
+          minHeight: heightValue,
+          padding: `${asCssSize(data.contentPaddingY, '120px')} ${asCssSize(data.contentPaddingX, '96px')}`,
+          position: 'relative'
+        };
+      }
+
+      function heroBackgroundStyle(block) {
+        const data = block.data || {};
+        const image = data.backgroundImage ? `url(${data.backgroundImage})` : 'none';
+        return {
+          backgroundImage: image,
+          backgroundPosition: data.backgroundPosition || 'center center',
+          backgroundSize: data.backgroundSize || 'cover',
+          backgroundRepeat: data.backgroundRepeat || 'no-repeat'
+        };
+      }
+
+      function heroOverlayStyle(block) {
+        const data = block.data || {};
+        const styles = {
+          background: data.overlayColor || 'rgba(17, 24, 39, 0.55)'
+        };
+        const blurValue = parseFloat(data.overlayBlur);
+        if (!Number.isNaN(blurValue) && blurValue > 0) {
+          styles.backdropFilter = `blur(${blurValue}px)`;
+        }
+        return styles;
+      }
+
+      function heroContainerClasses(block) {
+        const data = block.data || {};
+        const layout = data.layout || 'split';
+        if (layout === 'split') {
+          const classes = ['relative', 'grid', 'items-center', 'w-full'];
+          if (data.showRightImage) {
+            classes.push('lg:grid-cols-2');
+          } else {
+            classes.push('grid-cols-1');
+          }
+          return classes.join(' ');
+        }
+        if (layout === 'freeform') {
+          return 'relative flex flex-col w-full';
+        }
+        return 'relative flex flex-col items-center w-full';
+      }
+
+      function heroContainerStyle(block) {
+        const data = block.data || {};
+        const layout = data.layout || 'split';
+        if (layout === 'freeform') {
+          return {
+            gap: '0px',
+            position: 'relative',
+            width: '100%'
+          };
+        }
+        return {
+          gap: asCssSize(data.contentGap, '40px')
+        };
+      }
+
+      function heroContentColumnClasses(block) {
+        const data = block.data || {};
+        const layout = data.layout || 'split';
+        if (layout === 'freeform') {
+          return 'relative w-full min-h-[320px]';
+        }
+        const classes = ['space-y-4', 'w-full'];
+        if (layout === 'split') {
+          classes.push('text-left');
+          if (data.imageSide === 'left' && data.showRightImage) {
+            classes.push('lg:order-2');
+          }
+        } else {
+          classes.push('mx-auto', 'text-center');
+          if (layout === 'spotlight') {
+            classes.push('order-2');
+          }
+        }
+        return classes.join(' ');
+      }
+
+      function heroContentStyle(block) {
+        const data = block.data || {};
+        const style = {
+          maxWidth: asCssSize(data.contentMaxWidth, '620px'),
+          width: '100%'
+        };
+        if (data.layout === 'freeform') {
+          style.position = 'relative';
+          style.minHeight = asCssSize(data.freeformHeight || data.minHeight, '640px');
+        } else if (data.layout && data.layout !== 'split') {
+          style.marginLeft = 'auto';
+          style.marginRight = 'auto';
+        }
+        return style;
+      }
+
+      function heroMediaWrapperClasses(block) {
+        const data = block.data || {};
+        if (!data.showRightImage) {
+          return 'hidden';
+        }
+        const layout = data.layout || 'split';
+        if (layout === 'freeform') {
+          return 'hidden';
+        }
+        if (layout === 'split') {
+          const classes = ['hidden', 'lg:flex', 'items-center', 'justify-center'];
+          if (data.imageSide === 'left') {
+            classes.push('lg:order-1');
+          }
+          return classes.join(' ');
+        }
+        if (layout === 'spotlight') {
+          return 'flex justify-center order-1 w-full mb-10';
+        }
+        return 'flex justify-center w-full mt-10';
+      }
+
+      function heroFeatureIconWrapperStyle(element) {
+        const data = element.data || {};
+        let borderRadius = '9999px';
+        if (data.iconShape === 'square') {
+          borderRadius = '12px';
+        } else if (data.iconShape === 'rounded') {
+          borderRadius = '18px';
+        }
+        return {
+          backgroundColor: data.iconBackground || 'rgba(249, 115, 22, 0.12)',
+          color: data.iconColor || '#f97316',
+          borderRadius
+        };
+      }
+
+      function handleWindowResize() {
+        scheduleSelectionOverlay();
+      }
+
+      function handleDocumentScroll() {
+        scheduleSelectionOverlay();
+      }
+
       function onHeroElementDragStart(blockId, elementId, event = null) {
+        const block = getBlockById(blockId);
+        const element = block?.data?.elements?.find(el => el.id === elementId) || null;
+        if (!block || !element || isFreeformBlock(block) || element.data?.positionMode === 'free') {
+          if (event?.preventDefault) {
+            event.preventDefault();
+          }
+          return;
+        }
         heroDrag.sourceBlockId = blockId;
         heroDrag.elementId = elementId;
         heroDrag.dropIndex = null;
@@ -1838,12 +2775,16 @@
 
       function onHeroElementDragOver(blockId, index) {
         if (!heroDrag.elementId) return;
+        const block = getBlockById(blockId);
+        if (isFreeformBlock(block)) return;
         heroDrag.targetBlockId = blockId;
         heroDrag.dropIndex = index;
       }
 
       function onHeroElementDragLeave(blockId, index) {
         if (!heroDrag.elementId) return;
+        const block = getBlockById(blockId);
+        if (isFreeformBlock(block)) return;
         if (heroDrag.targetBlockId === blockId && heroDrag.dropIndex === index) {
           heroDrag.dropIndex = null;
         }
@@ -1853,7 +2794,7 @@
         if (!heroDrag.elementId) return;
         const sourceBlock = pageBlocks.value.find(b => b.id === heroDrag.sourceBlockId);
         const targetBlock = pageBlocks.value.find(b => b.id === blockId);
-        if (!sourceBlock || !targetBlock || targetBlock.type !== 'hero') {
+        if (!sourceBlock || !targetBlock || targetBlock.type !== 'hero' || isFreeformBlock(targetBlock)) {
           onHeroElementDragEnd();
           return;
         }
@@ -1862,6 +2803,11 @@
         const targetElements = Array.isArray(targetBlock.data.elements) ? targetBlock.data.elements : [];
         const sourceIndex = sourceElements.findIndex(el => el.id === heroDrag.elementId);
         if (sourceIndex === -1) {
+          onHeroElementDragEnd();
+          return;
+        }
+
+        if (sourceElements[sourceIndex]?.data?.positionMode === 'free') {
           onHeroElementDragEnd();
           return;
         }
@@ -1878,6 +2824,7 @@
         selectedBlockId.value = targetBlock.id;
         currentElementId.value = element.id;
         onHeroElementDragEnd();
+        scheduleSelectionOverlay();
       }
 
       function selectElement(blockId, elementId) {
@@ -2069,11 +3016,13 @@
         if (!blocks.length) {
           selectedBlockId.value = null;
           currentElementId.value = null;
+          scheduleSelectionOverlay();
           return;
         }
         if (!blocks.some(block => block.id === selectedBlockId.value)) {
           selectedBlockId.value = blocks[0].id;
         }
+        nextTick(scheduleSelectionOverlay);
       }, { deep: true });
 
       watch(selectedBlockId, (nextId, prevId) => {
@@ -2087,10 +3036,45 @@
         if (!has) {
           currentElementId.value = block.data.elements[0].id;
         }
+        nextTick(scheduleSelectionOverlay);
+      });
+
+      watch(currentElementId, () => {
+        nextTick(scheduleSelectionOverlay);
+      });
+
+      watch(() => canvas.zoom, () => {
+        scheduleSelectionOverlay();
+      });
+
+      watch(() => canvas.mode, () => {
+        nextTick(scheduleSelectionOverlay);
+      });
+
+      watch(() => canvas.showOverlays, (value) => {
+        if (value) {
+          scheduleSelectionOverlay();
+        } else {
+          selectionOverlay.visible = false;
+        }
+      });
+
+      watch(() => canvas.device, () => {
+        nextTick(scheduleSelectionOverlay);
       });
 
       onMounted(async () => {
+        window.addEventListener('resize', handleWindowResize);
+        document.addEventListener('scroll', handleDocumentScroll, true);
         await loadSettings();
+        nextTick(scheduleSelectionOverlay);
+      });
+
+      onUnmounted(() => {
+        window.removeEventListener('resize', handleWindowResize);
+        document.removeEventListener('scroll', handleDocumentScroll, true);
+        window.removeEventListener('pointermove', onFreeformPointerMove);
+        window.removeEventListener('pointerup', onFreeformPointerUp);
       });
 
       return {
@@ -2104,6 +3088,8 @@
         canvas,
         canvasWidth,
         canvasStyle,
+        canvasViewportRef,
+        canvasInnerRef,
         dropIndex,
         selectedBlockId,
         selectedBlock,
@@ -2114,6 +3100,8 @@
         currentElement,
         currentElementDefinition,
         elementRegistry,
+        selectionOverlay,
+        selectionOverlayStyle,
         saveSettings,
         loadSettings,
         addBlock,
@@ -2137,13 +3125,19 @@
         heroElementProps,
         heroImageProps,
         heroElementWrapperClasses,
+        heroElementWrapperStyle,
+        heroElementDraggable,
         heroDropWrapperClass,
         heroDropLabelClass,
         onHeroElementDragStart,
         onHeroElementDragEnd,
+        onHeroElementPointerDown,
         onHeroElementDragOver,
         onHeroElementDragLeave,
         onHeroElementDrop,
+        handleBlockClick,
+        handleElementClick,
+        handleCanvasClick,
         selectElement,
         isElementSelected,
         addElement,
@@ -2155,7 +3149,19 @@
         onBlockFileSelected,
         onFileSelected,
         getElementFieldValue,
-        updateElementField
+        updateElementField,
+        registerBlockRef,
+        registerElementRef,
+        onCanvasScroll,
+        heroWrapperStyle,
+        heroBackgroundStyle,
+        heroOverlayStyle,
+        heroContainerClasses,
+        heroContainerStyle,
+        heroContentColumnClasses,
+        heroContentStyle,
+        heroMediaWrapperClasses,
+        heroFeatureIconWrapperStyle
       };
     }
   };

--- a/sushi-store/client/modules/adminSiteSettings.js
+++ b/sushi-store/client/modules/adminSiteSettings.js
@@ -2,986 +2,102 @@
 (function(){
   const { ref, reactive, computed, watch, onMounted, onUnmounted, nextTick } = Vue;
 
-  const elementRegistry = {
-    heading: {
-      label: 'Заголовок',
-      icon: 'fa-solid fa-heading',
-      defaultData: () => ({
-        text: 'Новый заголовок',
-        level: 'h2',
-        fontSize: 'text-3xl',
-        color: '#111827',
-        align: 'left',
-        marginTop: '0px',
-        marginBottom: '16px',
-        fontFamily: '',
-        fontWeight: '700',
-        lineHeight: '1.2',
-        letterSpacing: '0px',
-        textTransform: 'none',
-        backgroundColor: '',
-        paddingX: '0px',
-        paddingY: '0px',
-        borderRadius: '0px',
-        textShadow: '',
-        positionMode: 'flow',
-        positionX: '0px',
-        positionY: '0px',
-        zIndex: '10',
-        maxWidth: '640px'
-      }),
-      fields: [
-        { key: 'text', label: 'Текст', type: 'text', placeholder: 'Введите заголовок' },
-        {
-          key: 'level',
-          label: 'Уровень',
-          type: 'select',
-          options: [
-            { value: 'h1', label: 'H1' },
-            { value: 'h2', label: 'H2' },
-            { value: 'h3', label: 'H3' }
-          ]
-        },
-        {
-          key: 'fontSize',
-          label: 'Размер',
-          type: 'select',
-          options: [
-            { value: 'text-2xl', label: 'Крупный (2xl)' },
-            { value: 'text-3xl', label: 'Очень крупный (3xl)' },
-            { value: 'text-4xl', label: 'Заголовок (4xl)' }
-          ]
-        },
-        {
-          key: 'fontWeight',
-          label: 'Начертание',
-          type: 'select',
-          options: [
-            { value: '400', label: 'Обычный' },
-            { value: '500', label: 'Средний' },
-            { value: '600', label: 'Полужирный' },
-            { value: '700', label: 'Жирный' },
-            { value: '800', label: 'Экстра жирный' }
-          ]
-        },
-        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Manrope"' },
-        { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.2' },
-        { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
-        {
-          key: 'textTransform',
-          label: 'Регистр',
-          type: 'select',
-          options: [
-            { value: 'none', label: 'Обычный' },
-            { value: 'uppercase', label: 'Верхний' },
-            { value: 'lowercase', label: 'Нижний' },
-            { value: 'capitalize', label: 'Каждое слово' }
-          ]
-        },
-        {
-          key: 'color',
-          label: 'Цвет текста',
-          type: 'color'
-        },
-        {
-          key: 'align',
-          label: 'Выравнивание',
-          type: 'select',
-          options: [
-            { value: 'left', label: 'Слева' },
-            { value: 'center', label: 'По центру' },
-            { value: 'right', label: 'Справа' }
-          ]
-        },
-        { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' },
-        { key: 'backgroundColor', label: 'Фон текста', type: 'color' },
-        { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '0px' },
-        { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '0px' },
-        { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '0px' },
-        { key: 'textShadow', label: 'Тень текста', type: 'text', placeholder: '0 10px 30px rgba(15,23,42,0.35)' },
-        {
-          key: 'positionMode',
-          label: 'Расположение',
-          type: 'select',
-          options: [
-            { value: 'flow', label: 'В потоке' },
-            { value: 'free', label: 'Свободное' }
-          ]
-        },
-        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
-        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
-        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '10' },
-        { key: 'maxWidth', label: 'Макс. ширина', type: 'text', placeholder: '640px' }
-      ]
-    },
-    subheading: {
-      label: 'Подзаголовок',
-      icon: 'fa-solid fa-text-height',
-      defaultData: () => ({
-        text: 'Новый подзаголовок',
-        fontSize: 'text-xl',
-        color: '#f97316',
-        align: 'left',
-        marginTop: '0px',
-        marginBottom: '12px',
-        fontFamily: '',
-        fontWeight: '600',
-        lineHeight: '1.4',
-        letterSpacing: '0px',
-        textTransform: 'none',
-        backgroundColor: '',
-        paddingX: '0px',
-        paddingY: '0px',
-        borderRadius: '0px',
-        textShadow: '',
-        positionMode: 'flow',
-        positionX: '0px',
-        positionY: '0px',
-        zIndex: '10',
-        maxWidth: '640px'
-      }),
-      fields: [
-        { key: 'text', label: 'Текст', type: 'text', placeholder: 'Введите подзаголовок' },
-        {
-          key: 'fontSize',
-          label: 'Размер',
-          type: 'select',
-          options: [
-            { value: 'text-lg', label: 'Крупный' },
-            { value: 'text-xl', label: 'Очень крупный' },
-            { value: 'text-2xl', label: 'Заголовочный' }
-          ]
-        },
-        {
-          key: 'fontWeight',
-          label: 'Начертание',
-          type: 'select',
-          options: [
-            { value: '400', label: 'Обычный' },
-            { value: '500', label: 'Средний' },
-            { value: '600', label: 'Полужирный' },
-            { value: '700', label: 'Жирный' }
-          ]
-        },
-        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Inter"' },
-        { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.4' },
-        { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
-        {
-          key: 'textTransform',
-          label: 'Регистр',
-          type: 'select',
-          options: [
-            { value: 'none', label: 'Обычный' },
-            { value: 'uppercase', label: 'Верхний' },
-            { value: 'lowercase', label: 'Нижний' },
-            { value: 'capitalize', label: 'Каждое слово' }
-          ]
-        },
-        {
-          key: 'color',
-          label: 'Цвет текста',
-          type: 'color'
-        },
-        {
-          key: 'align',
-          label: 'Выравнивание',
-          type: 'select',
-          options: [
-            { value: 'left', label: 'Слева' },
-            { value: 'center', label: 'По центру' },
-            { value: 'right', label: 'Справа' }
-          ]
-        },
-        { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '12px' },
-        { key: 'backgroundColor', label: 'Фон текста', type: 'color' },
-        { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '0px' },
-        { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '0px' },
-        { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '0px' },
-        { key: 'textShadow', label: 'Тень текста', type: 'text', placeholder: '0 6px 20px rgba(15,23,42,0.25)' },
-        {
-          key: 'positionMode',
-          label: 'Расположение',
-          type: 'select',
-          options: [
-            { value: 'flow', label: 'В потоке' },
-            { value: 'free', label: 'Свободное' }
-          ]
-        },
-        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
-        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
-        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '10' },
-        { key: 'maxWidth', label: 'Макс. ширина', type: 'text', placeholder: '640px' }
-      ]
-    },
-    paragraph: {
-      label: 'Текст',
-      icon: 'fa-solid fa-paragraph',
-      defaultData: () => ({
-        text: 'Добавьте описание секции или товара',
-        fontSize: 'text-base',
-        color: '#4b5563',
-        align: 'left',
-        marginTop: '0px',
-        marginBottom: '16px',
-        fontFamily: '',
-        fontWeight: '400',
-        lineHeight: '1.6',
-        letterSpacing: '0px',
-        textTransform: 'none',
-        maxWidth: '640px',
-        backgroundColor: '',
-        paddingX: '0px',
-        paddingY: '0px',
-        borderRadius: '0px',
-        textShadow: '',
-        positionMode: 'flow',
-        positionX: '0px',
-        positionY: '0px',
-        zIndex: '10'
-      }),
-      fields: [
-        { key: 'text', label: 'Текст', type: 'textarea', rows: 3, placeholder: 'Расскажите подробнее' },
-        {
-          key: 'fontSize',
-          label: 'Размер',
-          type: 'select',
-          options: [
-            { value: 'text-sm', label: 'Маленький' },
-            { value: 'text-base', label: 'Стандартный' },
-            { value: 'text-lg', label: 'Крупный' }
-          ]
-        },
-        {
-          key: 'fontWeight',
-          label: 'Начертание',
-          type: 'select',
-          options: [
-            { value: '300', label: 'Светлый' },
-            { value: '400', label: 'Обычный' },
-            { value: '500', label: 'Средний' },
-            { value: '600', label: 'Полужирный' }
-          ]
-        },
-        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Rubik"' },
-        { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.6' },
-        { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
-        {
-          key: 'textTransform',
-          label: 'Регистр',
-          type: 'select',
-          options: [
-            { value: 'none', label: 'Обычный' },
-            { value: 'uppercase', label: 'Верхний' },
-            { value: 'lowercase', label: 'Нижний' },
-            { value: 'capitalize', label: 'Каждое слово' }
-          ]
-        },
-        { key: 'maxWidth', label: 'Максимальная ширина', type: 'text', placeholder: '640px' },
-        {
-          key: 'color',
-          label: 'Цвет текста',
-          type: 'color'
-        },
-        {
-          key: 'align',
-          label: 'Выравнивание',
-          type: 'select',
-          options: [
-            { value: 'left', label: 'Слева' },
-            { value: 'center', label: 'По центру' },
-            { value: 'right', label: 'Справа' }
-          ]
-        },
-        { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' },
-        { key: 'backgroundColor', label: 'Фон текста', type: 'color' },
-        { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '0px' },
-        { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '0px' },
-        { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '0px' },
-        { key: 'textShadow', label: 'Тень текста', type: 'text', placeholder: '0 4px 16px rgba(15,23,42,0.15)' },
-        {
-          key: 'positionMode',
-          label: 'Расположение',
-          type: 'select',
-          options: [
-            { value: 'flow', label: 'В потоке' },
-            { value: 'free', label: 'Свободное' }
-          ]
-        },
-        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
-        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
-        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '10' }
-      ]
-    },
-    button: {
-      label: 'Кнопка',
-      icon: 'fa-solid fa-hand-pointer',
-      defaultData: () => ({
-        text: 'Новая кнопка',
-        style: 'primary',
-        action: 'scrollMenu',
-        href: '',
-        align: 'left',
-        marginTop: '0px',
-        marginBottom: '0px',
-        backgroundColor: '#ffffff',
-        textColor: '#dc2626',
-        hoverBackgroundColor: '#f3f4f6',
-        hoverTextColor: '#b91c1c',
-        borderRadius: '9999px',
-        borderWidth: '0px',
-        borderColor: '#ffffff',
-        paddingX: '28px',
-        paddingY: '14px',
-        fontSize: '16px',
-        fontFamily: '',
-        fontWeight: '600',
-        boxShadow: '0 15px 40px rgba(255,255,255,0.18)',
-        positionMode: 'flow',
-        positionX: '0px',
-        positionY: '0px',
-        zIndex: '20',
-        width: ''
-      }),
-      fields: [
-        { key: 'text', label: 'Текст кнопки', type: 'text', placeholder: 'Например, Заказать' },
-        {
-          key: 'style',
-          label: 'Стиль',
-          type: 'select',
-          options: [
-            { value: 'primary', label: 'Заливка' },
-            { value: 'secondary', label: 'Контур' }
-          ]
-        },
-        {
-          key: 'action',
-          label: 'Действие',
-          type: 'select',
-          options: [
-            { value: 'scrollMenu', label: 'Прокрутка к меню' },
-            { value: 'openCart', label: 'Открыть корзину' },
-            { value: 'link', label: 'Ссылка' }
-          ]
-        },
-        { key: 'href', label: 'Ссылка', type: 'text', placeholder: 'https://...' },
-        { key: 'fontSize', label: 'Размер шрифта (px)', type: 'text', placeholder: '16px' },
-        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Nunito"' },
-        {
-          key: 'fontWeight',
-          label: 'Начертание',
-          type: 'select',
-          options: [
-            { value: '500', label: 'Средний' },
-            { value: '600', label: 'Полужирный' },
-            { value: '700', label: 'Жирный' }
-          ]
-        },
-        {
-          key: 'align',
-          label: 'Выравнивание',
-          type: 'select',
-          options: [
-            { value: 'left', label: 'Слева' },
-            { value: 'center', label: 'По центру' },
-            { value: 'right', label: 'Справа' }
-          ]
-        },
-        { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '0px' },
-        { key: 'backgroundColor', label: 'Цвет фона', type: 'color' },
-        { key: 'textColor', label: 'Цвет текста', type: 'color' },
-        { key: 'hoverBackgroundColor', label: 'Фон при наведении', type: 'color' },
-        { key: 'hoverTextColor', label: 'Текст при наведении', type: 'color' },
-        { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '9999px' },
-        { key: 'borderWidth', label: 'Толщина границы', type: 'text', placeholder: '0px' },
-        { key: 'borderColor', label: 'Цвет границы', type: 'color' },
-        { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '28px' },
-        { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '14px' },
-        { key: 'boxShadow', label: 'Тень', type: 'text', placeholder: '0 15px 40px rgba(255,255,255,0.18)' },
-        {
-          key: 'positionMode',
-          label: 'Расположение',
-          type: 'select',
-          options: [
-            { value: 'flow', label: 'В потоке' },
-            { value: 'free', label: 'Свободное' }
-          ]
-        },
-        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
-        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
-        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '20' },
-        { key: 'width', label: 'Ширина', type: 'text', placeholder: 'auto' }
-      ]
-    },
-    image: {
-      label: 'Изображение',
-      icon: 'fa-solid fa-image',
-      defaultData: () => ({
-        src: '',
-        alt: 'Изображение',
-        width: '320px',
-        height: 'auto',
-        align: 'left',
-        borderRadius: '16px',
-        marginTop: '0px',
-        marginBottom: '16px',
-        objectFit: 'cover',
-        boxShadow: '0 25px 60px rgba(15,23,42,0.35)',
-        borderWidth: '0px',
-        borderColor: 'rgba(255,255,255,0.2)',
-        backgroundColor: 'transparent',
-        positionMode: 'flow',
-        positionX: '0px',
-        positionY: '0px',
-        zIndex: '5'
-      }),
-      fields: [
-        { key: 'src', label: 'URL изображения', type: 'text', placeholder: 'https://...' },
-        { key: 'alt', label: 'Alt текст', type: 'text', placeholder: 'Подпись' },
-        { key: 'width', label: 'Ширина', type: 'text', placeholder: '320px' },
-        { key: 'height', label: 'Высота', type: 'text', placeholder: 'auto' },
-        {
-          key: 'align',
-          label: 'Выравнивание',
-          type: 'select',
-          options: [
-            { value: 'left', label: 'Слева' },
-            { value: 'center', label: 'По центру' },
-            { value: 'right', label: 'Справа' }
-          ]
-        },
-        { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '16px' },
-        { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' },
-        {
-          key: 'objectFit',
-          label: 'Вписывание',
-          type: 'select',
-          options: [
-            { value: 'cover', label: 'Cover' },
-            { value: 'contain', label: 'Contain' },
-            { value: 'fill', label: 'Fill' }
-          ]
-        },
-        { key: 'boxShadow', label: 'Тень', type: 'text', placeholder: '0 25px 60px rgba(15,23,42,0.35)' },
-        { key: 'borderWidth', label: 'Толщина границы', type: 'text', placeholder: '0px' },
-        { key: 'borderColor', label: 'Цвет границы', type: 'color' },
-        { key: 'backgroundColor', label: 'Фон', type: 'color' },
-        {
-          key: 'positionMode',
-          label: 'Расположение',
-          type: 'select',
-          options: [
-            { value: 'flow', label: 'В потоке' },
-            { value: 'free', label: 'Свободное' }
-          ]
-        },
-        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
-        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
-        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '5' }
-      ]
-    },
-    feature: {
-      label: 'Преимущество',
-      icon: 'fa-solid fa-star',
-      defaultData: () => ({
-        text: 'Новое преимущество',
-        icon: 'fa-solid fa-check',
-        color: '#111827',
-        fontSize: 'text-base',
-        marginTop: '0px',
-        marginBottom: '8px',
-        fontFamily: '',
-        fontWeight: '500',
-        lineHeight: '1.4',
-        letterSpacing: '0px',
-        textTransform: 'none',
-        iconColor: '#f97316',
-        iconBackground: 'rgba(249, 115, 22, 0.12)',
-        iconShape: 'circle',
-        positionMode: 'flow',
-        positionX: '0px',
-        positionY: '0px',
-        zIndex: '15'
-      }),
-      fields: [
-        { key: 'text', label: 'Текст', type: 'text', placeholder: 'Например, Бесплатная доставка' },
-        { key: 'icon', label: 'Иконка FontAwesome', type: 'text', placeholder: 'fa-solid fa-check' },
-        { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Open Sans"' },
-        {
-          key: 'fontWeight',
-          label: 'Начертание',
-          type: 'select',
-          options: [
-            { value: '400', label: 'Обычный' },
-            { value: '500', label: 'Средний' },
-            { value: '600', label: 'Полужирный' }
-          ]
-        },
-        {
-          key: 'color',
-          label: 'Цвет текста',
-          type: 'color'
-        },
-        {
-          key: 'fontSize',
-          label: 'Размер',
-          type: 'select',
-          options: [
-            { value: 'text-sm', label: 'Маленький' },
-            { value: 'text-base', label: 'Стандартный' },
-            { value: 'text-lg', label: 'Крупный' }
-          ]
-        },
-        { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.4' },
-        { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
-        {
-          key: 'textTransform',
-          label: 'Регистр',
-          type: 'select',
-          options: [
-            { value: 'none', label: 'Обычный' },
-            { value: 'uppercase', label: 'Верхний' },
-            { value: 'capitalize', label: 'Каждое слово' }
-          ]
-        },
-        { key: 'iconColor', label: 'Цвет иконки', type: 'color' },
-        { key: 'iconBackground', label: 'Фон иконки', type: 'color' },
-        {
-          key: 'iconShape',
-          label: 'Форма иконки',
-          type: 'select',
-          options: [
-            { value: 'circle', label: 'Круг' },
-            { value: 'rounded', label: 'Скруглённый квадрат' },
-            { value: 'square', label: 'Квадрат' }
-          ]
-        },
-        { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '8px' },
-        {
-          key: 'positionMode',
-          label: 'Расположение',
-          type: 'select',
-          options: [
-            { value: 'flow', label: 'В потоке' },
-            { value: 'free', label: 'Свободное' }
-          ]
-        },
-        { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
-        { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
-        { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '15' }
-      ]
-    },
-    spacer: {
-      label: 'Отступ',
-      icon: 'fa-solid fa-ruler-vertical',
-      defaultData: () => ({
-        height: '24px',
-        marginTop: '0px',
-        marginBottom: '0px'
-      }),
-      fields: [
-        { key: 'height', label: 'Высота', type: 'text', placeholder: '24px' },
-        { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
-        { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '0px' }
-      ]
-    }
-  };
+  const builder = window.SiteBuilder;
+  if (!builder) {
+    console.error('SiteBuilder core module is not loaded. AdminSiteSettingsView не может инициализироваться.');
+    return;
+  }
+  const { elementRegistry, blockRegistry, deepClone, generateId, normalizeElement, createBlockInstance } = builder;
 
-  const blockRegistry = {
-    hero: {
-      name: 'Hero-блок',
-      icon: 'fa-solid fa-fire',
-      defaultData: () => ({
-        heading: 'Быстро и вкусно',
-        subheading: 'Попробуйте наши фирменные суши',
-        description: 'Свежие роллы, пицца и десерты с доставкой за 30 минут.',
-        buttonText: 'Выбрать блюда',
-        buttonStyle: 'primary',
-        buttonAction: 'scrollMenu',
-        buttonLink: '',
-        backgroundImage: 'https://images.unsplash.com/photo-1579952363873-27d3bfad9c0d',
-        previewImage: 'https://images.unsplash.com/photo-1607301405418-780ee5e6dd10',
-        imageSide: 'right',
-        showRightImage: true,
-        waveEnabled: true,
-        waveColor: '#f9f4e5',
-        overlayColor: 'rgba(17, 24, 39, 0.55)',
-        contentMaxWidth: '620px',
-        contentPaddingX: '96px',
-        contentPaddingY: '120px',
-        contentGap: '40px',
-        minHeight: '640px',
-        freeformHeight: '640px',
-        layout: 'split',
-        backgroundPosition: 'center center',
-        backgroundSize: 'cover',
-        backgroundRepeat: 'no-repeat',
-        overlayBlur: '0',
-        elements: [
-          {
-            type: 'heading',
-            data: {
-              text: 'Быстро и вкусно',
-              level: 'h1',
-              fontSize: 'text-5xl',
-              color: '#ffffff',
-              align: 'left',
-              marginTop: '0px',
-              marginBottom: '16px'
-            }
-          },
-          {
-            type: 'subheading',
-            data: {
-              text: 'Попробуйте фирменные роллы сегодня',
-              fontSize: 'text-2xl',
-              color: '#fbbf24',
-              align: 'left',
-              marginTop: '0px',
-              marginBottom: '12px'
-            }
-          },
-          {
-            type: 'paragraph',
-            data: {
-              text: 'Комбинируйте суши, пиццу и десерты. Мы доставим всё тёплым и свежим.',
-              fontSize: 'text-lg',
-              color: '#f9fafb',
-              align: 'left',
-              marginTop: '0px',
-              marginBottom: '20px'
-            }
-          },
-          {
-            type: 'button',
-            data: {
-              text: 'Собрать заказ',
-              style: 'primary',
-              action: 'scrollMenu',
-              align: 'left',
-              marginTop: '0px',
-              marginBottom: '0px'
-            }
-          }
-        ]
-      }),
-      inspector: [
-        {
-          label: 'Контент',
-          fields: [
-            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Быстро и вкусно' },
-            { key: 'subheading', label: 'Подзаголовок', type: 'text', placeholder: 'Попробуйте наши фирменные суши' },
-            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Коротко о предложении' }
-          ]
-        },
-        {
-          label: 'Кнопка',
-          fields: [
-            { key: 'buttonText', label: 'Текст кнопки', type: 'text', placeholder: 'Выбрать блюда' },
-            {
-              key: 'buttonStyle',
-              label: 'Стиль кнопки',
-              type: 'select',
-              options: [
-                { value: 'primary', label: 'Основная' },
-                { value: 'secondary', label: 'Вторичная' }
-              ]
-            },
-            {
-              key: 'buttonAction',
-              label: 'Действие',
-              type: 'select',
-              options: [
-                { value: 'scrollMenu', label: 'Прокрутка к меню' },
-                { value: 'openCart', label: 'Открыть корзину' },
-                { value: 'link', label: 'Перейти по ссылке' }
-              ]
-            },
-            { key: 'buttonLink', label: 'Ссылка (для действия "Ссылка")', type: 'text', placeholder: 'https://...' }
-          ]
-        },
-        {
-          label: 'Макет',
-          fields: [
-            {
-              key: 'layout',
-              label: 'Расположение',
-              type: 'select',
-              options: [
-                { value: 'split', label: 'Текст и изображение' },
-                { value: 'stacked', label: 'Только текст' },
-                { value: 'spotlight', label: 'Текст над изображением' },
-                { value: 'freeform', label: 'Свободное расположение' }
-              ]
-            },
-            { key: 'contentMaxWidth', label: 'Ширина контента', type: 'text', placeholder: '620px' },
-            { key: 'contentPaddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '96px' },
-            { key: 'contentPaddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '120px' },
-            { key: 'contentGap', label: 'Отступ между колонками', type: 'text', placeholder: '40px' },
-            { key: 'minHeight', label: 'Минимальная высота', type: 'text', placeholder: '640px' },
-            { key: 'freeformHeight', label: 'Высота для свободного режима', type: 'text', placeholder: '640px' }
-          ]
-        },
-        {
-          label: 'Оформление',
-          fields: [
-            { key: 'backgroundImage', label: 'Фоновое изображение', type: 'image' },
-            { key: 'previewImage', label: 'Изображение справа', type: 'image' },
-            {
-              key: 'imageSide',
-              label: 'Расположение изображения',
-              type: 'select',
-              options: [
-                { value: 'left', label: 'Слева' },
-                { value: 'right', label: 'Справа' }
-              ]
-            },
-            { key: 'showRightImage', label: 'Показывать изображение', type: 'toggle' },
-            { key: 'waveEnabled', label: 'Декоративная волна', type: 'toggle' },
-            { key: 'waveColor', label: 'Цвет волны', type: 'color' },
-            { key: 'overlayColor', label: 'Цвет наложения', type: 'color' },
-            { key: 'backgroundPosition', label: 'Позиция фона', type: 'text', placeholder: 'center center' },
-            { key: 'backgroundSize', label: 'Размер фона', type: 'text', placeholder: 'cover' },
-            { key: 'backgroundRepeat', label: 'Повторение фона', type: 'text', placeholder: 'no-repeat' },
-            { key: 'overlayBlur', label: 'Размытие наложения (px)', type: 'text', placeholder: '0' }
-          ]
-        }
-      ],
-      elements: ['heading', 'subheading', 'paragraph', 'button', 'image', 'feature', 'spacer']
-    },
-    categories: {
-      name: 'Категории',
-      icon: 'fa-solid fa-tags',
-      defaultData: () => ({
-        heading: 'Категории и блюда',
-        subheading: 'которые вы нигде не найдете',
-        description: 'Уникальные подборки от наших шефов',
-        backgroundColor: '#f9f4e5',
-        accentColor: '#f97316',
-        cardStyle: 'rounded'
-      }),
-      inspector: [
-        {
-          label: 'Контент',
-          fields: [
-            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Категории и блюда' },
-            { key: 'subheading', label: 'Подзаголовок', type: 'text', placeholder: 'которые вы нигде не найдете' },
-            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Опишите секцию' }
-          ]
-        },
-        {
-          label: 'Оформление',
-          fields: [
-            { key: 'backgroundColor', label: 'Фон блока', type: 'color' },
-            { key: 'accentColor', label: 'Акцентный цвет', type: 'color' },
-            {
-              key: 'cardStyle',
-              label: 'Стиль карточек',
-              type: 'select',
-              options: [
-                { value: 'rounded', label: 'Скруглённые' },
-                { value: 'flat', label: 'Плоские' },
-                { value: 'glass', label: 'Стекло' }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    menu: {
-      name: 'Меню',
-      icon: 'fa-solid fa-utensils',
-      defaultData: () => ({
-        heading: 'Популярные блюда',
-        description: 'Выберите категорию и сформируйте свой сет',
-        showSearch: true,
-        highlightHits: true
-      }),
-      inspector: [
-        {
-          label: 'Контент',
-          fields: [
-            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Популярные блюда' },
-            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Выберите категорию и сформируйте свой сет' }
-          ]
-        },
-        {
-          label: 'Функции',
-          fields: [
-            { key: 'showSearch', label: 'Показывать поиск', type: 'toggle' },
-            { key: 'highlightHits', label: 'Подсвечивать хиты', type: 'toggle' }
-          ]
-        }
-      ]
-    },
-    delivery: {
-      name: 'Доставка',
-      icon: 'fa-solid fa-truck-fast',
-      defaultData: () => ({
-        heading: 'Быстрая доставка',
-        description: 'Привезём заказ за 30 минут или подарим ролл',
-        features: [
-          'Бесплатная доставка от 1500 ₽',
-          'Прозрачный трекинг курьера',
-          'Термосумки для горячих блюд'
-        ],
-        backgroundColor: '#fff7ed',
-        contactPhone: '+7 (900) 000-00-00',
-        minOrder: '1500'
-      }),
-      inspector: [
-        {
-          label: 'Контент',
-          fields: [
-            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Быстрая доставка' },
-            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Расскажите об условиях доставки' }
-          ]
-        },
-        {
-          label: 'Преимущества',
-          fields: [
-            { key: 'features', label: 'Список преимуществ', type: 'list', placeholder: 'Каждое с новой строки' }
-          ]
-        },
-        {
-          label: 'Дополнительно',
-          fields: [
-            { key: 'contactPhone', label: 'Телефон курьера', type: 'text', placeholder: '+7 (900) 000-00-00' },
-            { key: 'minOrder', label: 'Минимальный заказ', type: 'text', placeholder: '1500' },
-            { key: 'backgroundColor', label: 'Цвет фона', type: 'color' }
-          ]
-        }
-      ]
-    },
-    reviews: {
-      name: 'Отзывы',
-      icon: 'fa-solid fa-comments',
-      defaultData: () => ({
-        heading: 'Отзывы наших гостей',
-        description: 'Более 1000 довольных клиентов в этом месяце',
-        autoPlay: true,
-        layout: 'grid'
-      }),
-      inspector: [
-        {
-          label: 'Контент',
-          fields: [
-            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Отзывы наших гостей' },
-            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Более 1000 довольных клиентов' }
-          ]
-        },
-        {
-          label: 'Настройки',
-          fields: [
-            { key: 'autoPlay', label: 'Автопрокрутка', type: 'toggle' },
-            {
-              key: 'layout',
-              label: 'Макет',
-              type: 'select',
-              options: [
-                { value: 'grid', label: 'Сетка' },
-                { value: 'carousel', label: 'Карусель' }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    map: {
-      name: 'Карта и контакты',
-      icon: 'fa-solid fa-map-location-dot',
-      defaultData: () => ({
-        heading: 'Зоны доставки',
-        description: 'Нажмите на нужный район, чтобы узнать условия доставки',
-        iframeSrc: 'https://yandex.ru/map-widget/v1/?lang=ru_RU&scroll=true&source=constructor-api&um=constructor%3A1569f1da7d596921cd82db1f441ffc63d2a386db371645fede23dbc26dc86a74',
-        address: 'г. Санкт-Петербург, ул. Суши, 5',
-        workHours: 'Ежедневно 10:00 — 23:00',
-        phone: '+7 (812) 000-00-00'
-      }),
-      inspector: [
-        {
-          label: 'Контент',
-          fields: [
-            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Зоны доставки' },
-            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Опишите как работает доставка' }
-          ]
-        },
-        {
-          label: 'Контакты',
-          fields: [
-            { key: 'address', label: 'Адрес', type: 'text', placeholder: 'г. Санкт-Петербург...' },
-            { key: 'phone', label: 'Телефон', type: 'text', placeholder: '+7 (...)' },
-            { key: 'workHours', label: 'Время работы', type: 'text', placeholder: '10:00 — 23:00' }
-          ]
-        },
-        {
-          label: 'Карта',
-          fields: [
-            { key: 'iframeSrc', label: 'Ссылка на карту (iframe)', type: 'textarea', rows: 2 }
-          ]
-        }
-      ]
-    }
-  };
-
-  const deepClone = (value) => JSON.parse(JSON.stringify(value));
-
-  function generateId(prefix) {
-    return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
+  const styleHelpers = builder.styles || window.SiteBuilderStyles;
+  if (!styleHelpers) {
+    console.error('SiteBuilder style helpers module is not loaded. AdminSiteSettingsView не может инициализироваться.');
+    return;
   }
 
-  function normalizeElement(elementLike) {
-    if (!elementLike) {
-      return null;
-    }
-    const type = elementLike.type || 'paragraph';
-    const definition = elementRegistry[type];
-    if (!definition) {
-      return null;
-    }
-    const base = definition.defaultData ? definition.defaultData() : {};
-    const incoming = elementLike.data || {};
-    return {
-      id: elementLike.id || generateId('element'),
-      type,
-      data: { ...base, ...incoming }
-    };
-  }
+  const {
+    heroImageProps,
+    sectionBackgroundStyle,
+    sectionOverlayStyle,
+    blockButtonWrapperStyle,
+    blockButtonClass,
+    blockButtonStyle,
+    categoriesSectionStyle,
+    categoriesOverlayStyle,
+    categoriesHeaderStyle,
+    categoriesHeadingStyle,
+    categoriesSubheadingStyle,
+    categoriesDescriptionStyle,
+    categoriesGridStyle,
+    categoriesCardStyle,
+    categoriesIconWrapperStyle,
+    categoriesCardTitleStyle,
+    categoriesCardDescriptionStyle,
+    menuSectionStyle,
+    menuOverlayStyle,
+    menuHeaderStyle,
+    menuHeadingStyle,
+    menuDescriptionStyle,
+    menuFilterSurfaceStyle,
+    menuTabsWrapperStyle,
+    menuActiveTabStyle,
+    menuTabStyle,
+    menuGridStyle,
+    menuCardStyle,
+    menuCardImageStyle,
+    menuCardTitleStyle,
+    menuCardDescriptionStyle,
+    menuPriceStyle,
+    menuTagStyle,
+    deliverySectionStyle,
+    deliveryOverlayStyle,
+    deliveryTextColumnStyle,
+    deliveryHeadingStyle,
+    deliveryDescriptionStyle,
+    deliveryFeatureIconStyle,
+    deliveryFeatureTextStyle,
+    deliveryContactsStyle,
+    deliveryTrackingCardStyle,
+    deliveryTrackingBarStyle,
+    deliveryTrackingTitleStyle,
+    deliveryTrackingDescriptionStyle,
+    deliveryTrackingProgressStyle,
+    reviewsSectionStyle,
+    reviewsOverlayStyle,
+    reviewsHeaderStyle,
+    reviewsHeadingStyle,
+    reviewsDescriptionStyle,
+    reviewsGridStyle,
+    reviewsCardStyle,
+    reviewsAvatarStyle,
+    reviewsCardTitleStyle,
+    reviewsCardSubtitleStyle,
+    reviewsRatingStyle,
+    reviewsQuoteStyle,
+    mapSectionStyle,
+    mapOverlayStyle,
+    mapFrameStyle,
+    mapIframeStyle,
+    mapInfoCardStyle,
+    mapHeadingStyle,
+    mapDescriptionStyle,
+    mapContactRowStyle,
+    mapContactIconStyle,
+    heroWrapperStyle,
+    heroBackgroundStyle,
+    heroOverlayStyle,
+    heroContainerClasses,
+    heroContainerStyle,
+    heroContentColumnClasses,
+    heroContentStyle,
+    heroMediaWrapperClasses,
+    heroFeatureIconWrapperStyle,
+    asCssSize,
+    parseCssNumber,
+    clampNumber
+  } = styleHelpers;
 
-  function createBlockInstance(type, source = {}) {
-    const definition = blockRegistry[type];
-    if (!definition) {
-      return null;
-    }
-    const defaults = definition.defaultData ? definition.defaultData() : {};
-    const data = source.data || source || {};
-    const merged = { ...defaults, ...data };
-
-    if (definition.elements) {
-      const elements = Array.isArray(data.elements) ? data.elements : defaults.elements;
-      merged.elements = Array.isArray(elements)
-        ? elements.map(el => normalizeElement(el)).filter(Boolean)
-        : [];
-    }
-
-    return {
-      id: source.id || generateId('block'),
-      type,
-      name: definition.name,
-      icon: definition.icon,
-      data: merged,
-      meta: {
-        hidden: !!(source.hidden || (source.meta && source.meta.hidden))
-      }
-    };
-  }
-
-  window.AdminSiteSettingsView = {
+window.AdminSiteSettingsView = {
     name: 'AdminSiteSettingsView',
     template: /* html */`
       <div class="min-h-screen bg-gray-50 py-8">
@@ -1435,77 +551,160 @@
                           </template>
 
                           <template v-else-if="block.type === 'categories'">
-                            <div class="py-14 px-10" :style="{ backgroundColor: block.data.backgroundColor || '#f9f4e5' }">
-                              <div class="text-center max-w-3xl mx-auto">
-                                <h2 class="text-3xl font-bold text-gray-900">{{ block.data.heading }}</h2>
-                                <p class="text-orange-600 font-semibold mt-1">{{ block.data.subheading }}</p>
-                                <p class="text-gray-600 mt-3">{{ block.data.description }}</p>
-                              </div>
-                              <div class="grid sm:grid-cols-2 gap-6 mt-10">
-                                <div v-for="n in 4" :key="n" class="p-6 bg-white rounded-2xl shadow hover:shadow-lg transition">
-                                  <div class="w-20 h-20 rounded-full bg-orange-100 mx-auto mb-4"></div>
-                                  <h3 class="font-semibold text-lg text-gray-900 text-center">Категория {{ n }}</h3>
-                                  <p class="text-sm text-gray-500 text-center">Управляется в админке категорий</p>
+                            <div class="relative overflow-hidden" :style="categoriesSectionStyle(block)">
+                              <div
+                                v-if="categoriesOverlayStyle(block)"
+                                class="absolute inset-0 pointer-events-none"
+                                :style="categoriesOverlayStyle(block)"
+                              ></div>
+                              <div class="relative space-y-10">
+                                <div :style="categoriesHeaderStyle(block)" class="space-y-3">
+                                  <h2 class="font-bold" :style="categoriesHeadingStyle(block)">{{ block.data.heading }}</h2>
+                                  <p class="font-semibold" :style="categoriesSubheadingStyle(block)">{{ block.data.subheading }}</p>
+                                  <p :style="categoriesDescriptionStyle(block)">{{ block.data.description }}</p>
+                                </div>
+                                <div class="grid" :style="categoriesGridStyle(block)">
+                                  <div v-for="n in 4" :key="n" :style="categoriesCardStyle(block)" class="transition">
+                                    <div :style="categoriesIconWrapperStyle(block)" class="mb-4">
+                                      <i class="fa-solid fa-bowl-food"></i>
+                                    </div>
+                                    <h3 class="font-semibold text-lg text-center" :style="categoriesCardTitleStyle(block)">
+                                      Категория {{ n }}
+                                    </h3>
+                                    <p class="mt-2 text-sm text-center" :style="categoriesCardDescriptionStyle(block)">
+                                      Управляется в разделе категорий
+                                    </p>
+                                  </div>
+                                </div>
+                                <div v-if="block.data.buttonVisible" :style="blockButtonWrapperStyle(block.data)">
+                                  <button
+                                    :class="blockButtonClass(block.data)"
+                                    :style="blockButtonStyle(block.data, { background: '#f97316', textColor: '#ffffff', secondaryBackground: '#ffffff', secondaryText: '#111827', shadow: block.data.buttonShadow || '0 16px 40px rgba(15,23,42,0.18)' })"
+                                  >
+                                    <span>{{ block.data.buttonText || 'Все категории' }}</span>
+                                    <i class="fa-solid fa-arrow-right-long" v-if="block.data.buttonStyle !== 'link'"></i>
+                                  </button>
                                 </div>
                               </div>
                             </div>
                           </template>
 
                           <template v-else-if="block.type === 'menu'">
-                            <div class="py-16 px-10 bg-gradient-to-br from-orange-50 to-red-50">
-                              <div class="text-center max-w-2xl mx-auto">
-                                <h2 class="text-3xl font-bold text-gray-900">{{ block.data.heading }}</h2>
-                                <p class="text-gray-600 mt-3">{{ block.data.description }}</p>
-                              </div>
-                              <div class="grid md:grid-cols-3 gap-6 mt-12">
-                                <div v-for="n in 3" :key="n" class="bg-white rounded-2xl shadow p-5 space-y-4">
-                                  <div class="h-32 rounded-xl bg-gray-100"></div>
-                                  <div class="font-semibold text-gray-900">Популярное блюдо {{ n }}</div>
-                                  <p class="text-sm text-gray-500">Описание и цена подтягиваются из каталога</p>
-                                  <div class="flex items-center justify-between text-sm text-gray-600">
-                                    <span>450 ₽</span>
-                                    <span class="inline-flex items-center space-x-1 text-orange-600">
-                                      <i class="fa-solid fa-star"></i>
-                                      <span>Хит</span>
-                                    </span>
+                            <div class="relative overflow-hidden" :style="menuSectionStyle(block)">
+                              <div
+                                v-if="menuOverlayStyle(block)"
+                                class="absolute inset-0 pointer-events-none"
+                                :style="menuOverlayStyle(block)"
+                              ></div>
+                              <div class="relative space-y-10">
+                                <div :style="menuHeaderStyle(block)" class="space-y-3">
+                                  <h2 class="font-bold" :style="menuHeadingStyle(block)">{{ block.data.heading }}</h2>
+                                  <p :style="menuDescriptionStyle(block)">{{ block.data.description }}</p>
+                                </div>
+                                <div
+                                  v-if="block.data.showSearch || block.data.showFilters || block.data.showCategoryTabs"
+                                  class="space-y-4"
+                                >
+                                  <div v-if="block.data.showSearch" class="flex items-center" :style="menuFilterSurfaceStyle(block)">
+                                    <i class="fa-solid fa-magnifying-glass opacity-70 mr-3"></i>
+                                    <span class="text-sm opacity-80">Поиск будет доступен посетителям</span>
                                   </div>
+                                  <div v-if="block.data.showCategoryTabs" class="flex flex-wrap gap-2" :style="menuTabsWrapperStyle(block)">
+                                    <span class="px-4 py-2 rounded-full text-sm font-medium" :style="menuActiveTabStyle(block)">
+                                      Суши
+                                    </span>
+                                    <span class="px-4 py-2 rounded-full text-sm" :style="menuTabStyle(block)">Роллы</span>
+                                    <span class="px-4 py-2 rounded-full text-sm" :style="menuTabStyle(block)">Сеты</span>
+                                  </div>
+                                  <div v-if="block.data.showFilters" class="flex items-center gap-2" :style="menuFilterSurfaceStyle(block)">
+                                    <i class="fa-solid fa-sliders opacity-70"></i>
+                                    <span class="text-sm opacity-80">Фильтры включены</span>
+                                  </div>
+                                </div>
+                                <div class="grid" :style="menuGridStyle(block)">
+                                  <div
+                                    v-for="n in Math.max(3, Number(block.data.cardsPerRow) || 3)"
+                                    :key="n"
+                                    :style="menuCardStyle(block)"
+                                    class="transition"
+                                  >
+                                    <div :style="menuCardImageStyle(block)">
+                                      <div class="w-full h-full flex items-center justify-center text-3xl text-orange-500">
+                                        🍣
+                                      </div>
+                                    </div>
+                                    <div class="mt-4 font-semibold" :style="menuCardTitleStyle(block)">
+                                      Популярное блюдо {{ n }}
+                                    </div>
+                                    <p class="mt-2 text-sm" :style="menuCardDescriptionStyle(block)">
+                                      Описание и цена берутся из каталога
+                                    </p>
+                                    <div class="mt-4 flex items-center justify-between text-sm">
+                                      <span :style="menuPriceStyle(block)">450 ₽</span>
+                                      <span
+                                        v-if="block.data.highlightHits"
+                                        class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold"
+                                        :style="menuTagStyle(block)"
+                                      >
+                                        <i class="fa-solid fa-star"></i>
+                                        <span>Хит</span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div v-if="block.data.buttonVisible" :style="blockButtonWrapperStyle(block.data)">
+                                  <button
+                                    :class="blockButtonClass(block.data)"
+                                    :style="blockButtonStyle(block.data, { background: '#f97316', textColor: '#ffffff', secondaryBackground: '#ffffff', secondaryText: '#111827', shadow: block.data.buttonShadow || '0 16px 40px rgba(249,115,22,0.35)' })"
+                                  >
+                                    <span>{{ block.data.buttonText || 'Открыть меню' }}</span>
+                                    <i class="fa-solid fa-arrow-right-long" v-if="block.data.buttonStyle !== 'link'"></i>
+                                  </button>
                                 </div>
                               </div>
                             </div>
                           </template>
 
                           <template v-else-if="block.type === 'delivery'">
-                            <div class="py-16 px-10" :style="{ backgroundColor: block.data.backgroundColor || '#fff7ed' }">
-                              <div class="grid lg:grid-cols-2 gap-10 items-start">
-                                <div class="space-y-4">
-                                  <h2 class="text-3xl font-bold text-gray-900">{{ block.data.heading }}</h2>
-                                  <p class="text-gray-600">{{ block.data.description }}</p>
+                            <div class="relative overflow-hidden" :style="deliverySectionStyle(block)">
+                              <div
+                                v-if="deliveryOverlayStyle(block)"
+                                class="absolute inset-0 pointer-events-none"
+                                :style="deliveryOverlayStyle(block)"
+                              ></div>
+                              <div class="relative" :class="deliveryLayoutClass(block)">
+                                <div class="space-y-4" :style="deliveryTextColumnStyle(block)">
+                                  <h2 class="font-bold" :style="deliveryHeadingStyle(block)">{{ block.data.heading }}</h2>
+                                  <p :style="deliveryDescriptionStyle(block)">{{ block.data.description }}</p>
                                   <ul class="space-y-3">
-                                    <li
-                                      v-for="feature in block.data.features"
-                                      :key="feature"
-                                      class="flex items-start space-x-3"
-                                    >
-                                      <span class="mt-1 inline-flex items-center justify-center w-6 h-6 rounded-full bg-orange-500 text-white text-xs">
-                                        <i class="fa-solid fa-check"></i>
-                                      </span>
-                                      <span class="text-gray-700 text-sm">{{ feature }}</span>
+                                    <li v-for="feature in block.data.features" :key="feature" class="flex items-start gap-3">
+                                      <span :style="deliveryFeatureIconStyle(block)"><i class="fa-solid fa-check"></i></span>
+                                      <span :style="deliveryFeatureTextStyle(block)">{{ feature }}</span>
                                     </li>
                                   </ul>
-                                  <div class="flex items-center space-x-4 text-sm text-gray-600 pt-4">
-                                    <span class="inline-flex items-center space-x-2"><i class="fa-solid fa-phone"></i><span>{{ block.data.contactPhone }}</span></span>
-                                    <span class="inline-flex items-center space-x-2"><i class="fa-solid fa-box"></i><span>Мин. заказ {{ block.data.minOrder }} ₽</span></span>
+                                  <div class="flex flex-wrap gap-4 text-sm pt-4" :style="deliveryContactsStyle(block)">
+                                    <span class="inline-flex items-center gap-2"><i class="fa-solid fa-phone"></i><span>{{ block.data.contactPhone }}</span></span>
+                                    <span class="inline-flex items-center gap-2"><i class="fa-solid fa-box"></i><span>Мин. заказ {{ block.data.minOrder }} ₽</span></span>
+                                  </div>
+                                  <div v-if="block.data.buttonVisible" :style="blockButtonWrapperStyle(block.data)">
+                                    <button
+                                      :class="blockButtonClass(block.data)"
+                                      :style="blockButtonStyle(block.data, { background: '#111827', textColor: '#ffffff', secondaryBackground: '#ffffff', secondaryText: '#111827', shadow: block.data.buttonShadow || '0 16px 36px rgba(15,23,42,0.18)' })"
+                                    >
+                                      <span>{{ block.data.buttonText || 'Условия доставки' }}</span>
+                                      <i class="fa-solid fa-arrow-right-long" v-if="block.data.buttonStyle !== 'link'"></i>
+                                    </button>
                                   </div>
                                 </div>
-                                <div class="bg-white rounded-2xl shadow-lg overflow-hidden">
-                                  <div class="bg-gradient-to-r from-orange-400 to-red-500 h-12"></div>
+                                <div v-if="block.data.showTrackingCard" :style="deliveryTrackingCardStyle(block)">
+                                  <div :style="deliveryTrackingBarStyle(block)"></div>
                                   <div class="p-6 space-y-4">
-                                    <h3 class="font-semibold text-gray-900">Трекинг курьера</h3>
+                                    <h3 class="font-semibold" :style="deliveryTrackingTitleStyle(block)">{{ block.data.trackingTitle }}</h3>
                                     <div class="space-y-2">
                                       <div class="w-full h-2 rounded-full bg-gray-100 overflow-hidden">
-                                        <div class="h-full bg-gradient-to-r from-orange-500 to-red-500 w-3/4"></div>
+                                        <div class="h-full" :style="deliveryTrackingProgressStyle(block)"></div>
                                       </div>
-                                      <p class="text-xs text-gray-500">Курьер уже рядом – доставит заказ в течение 10 минут</p>
+                                      <p class="text-xs" :style="deliveryTrackingDescriptionStyle(block)">{{ block.data.trackingDescription }}</p>
                                     </div>
                                   </div>
                                 </div>
@@ -1514,60 +713,81 @@
                           </template>
 
                           <template v-else-if="block.type === 'reviews'">
-                            <div class="py-16 px-10 bg-gradient-to-br from-orange-50 to-red-50">
-                              <div class="text-center max-w-2xl mx-auto">
-                                <h2 class="text-3xl font-bold text-gray-900">{{ block.data.heading }}</h2>
-                                <p class="text-gray-600 mt-3">{{ block.data.description }}</p>
-                              </div>
-                              <div class="grid md:grid-cols-3 gap-6 mt-12">
-                                <div v-for="n in 3" :key="n" class="bg-white rounded-2xl shadow p-6 space-y-3">
-                                  <div class="flex items-center space-x-3">
-                                    <div class="w-12 h-12 rounded-full bg-orange-100"></div>
-                                    <div>
-                                      <div class="font-semibold text-gray-900">Клиент {{ n }}</div>
-                                      <div class="text-xs text-gray-500">Постоянный клиент</div>
+                            <div class="relative overflow-hidden" :style="reviewsSectionStyle(block)">
+                              <div
+                                v-if="reviewsOverlayStyle(block)"
+                                class="absolute inset-0 pointer-events-none"
+                                :style="reviewsOverlayStyle(block)"
+                              ></div>
+                              <div class="relative space-y-10">
+                                <div :style="reviewsHeaderStyle(block)" class="space-y-3">
+                                  <h2 class="font-bold" :style="reviewsHeadingStyle(block)">{{ block.data.heading }}</h2>
+                                  <p :style="reviewsDescriptionStyle(block)">{{ block.data.description }}</p>
+                                </div>
+                                <div class="grid" :style="reviewsGridStyle(block)">
+                                  <div v-for="n in 3" :key="n" :style="reviewsCardStyle(block)">
+                                    <div class="flex items-center gap-3">
+                                      <div :style="reviewsAvatarStyle(block)">К{{ n }}</div>
+                                      <div>
+                                        <div class="font-semibold" :style="reviewsCardTitleStyle(block)">Клиент {{ n }}</div>
+                                        <div class="text-xs" :style="reviewsCardSubtitleStyle(block)">Постоянный клиент</div>
+                                      </div>
                                     </div>
+                                    <div class="flex space-x-1 text-sm mt-3" :style="reviewsRatingStyle(block)">
+                                      <i v-for="star in 5" :key="star" class="fa-solid fa-star"></i>
+                                    </div>
+                                    <p class="mt-3 text-sm" :style="reviewsQuoteStyle(block)">
+                                      «Каждый заказ приезжает горячим. Любим за сервис и бонусы»
+                                    </p>
                                   </div>
-                                  <div class="flex space-x-1 text-orange-500 text-sm">
-                                    <i v-for="star in 5" :key="star" class="fa-solid fa-star"></i>
-                                  </div>
-                                  <p class="text-sm text-gray-600">«Каждый заказ приезжает горячим. Любим за сервис и бонусы»</p>
                                 </div>
                               </div>
                             </div>
                           </template>
 
                           <template v-else-if="block.type === 'map'">
-                            <div class="py-16 px-10 bg-white">
-                              <div class="grid lg:grid-cols-3 gap-8">
+                            <div class="relative overflow-hidden" :style="mapSectionStyle(block)">
+                              <div
+                                v-if="mapOverlayStyle(block)"
+                                class="absolute inset-0 pointer-events-none"
+                                :style="mapOverlayStyle(block)"
+                              ></div>
+                              <div class="relative grid lg:grid-cols-3 gap-8">
                                 <div class="lg:col-span-2">
-                                  <div class="aspect-[3/2] rounded-2xl overflow-hidden shadow-lg border border-gray-200">
+                                  <div :style="mapFrameStyle(block)">
                                     <iframe
                                       :src="block.data.iframeSrc"
-                                      width="100%"
-                                      height="100%"
-                                      style="border:0"
                                       allowfullscreen
                                       loading="lazy"
+                                      :style="mapIframeStyle(block)"
                                     ></iframe>
                                   </div>
                                 </div>
-                                <div class="space-y-4">
-                                  <h2 class="text-3xl font-bold text-gray-900">{{ block.data.heading }}</h2>
-                                  <p class="text-gray-600">{{ block.data.description }}</p>
-                                  <div class="space-y-3 text-sm text-gray-700">
-                                    <div class="flex items-center space-x-2">
-                                      <i class="fa-solid fa-location-dot text-orange-500"></i>
+                                <div class="space-y-4" :style="mapInfoCardStyle(block)">
+                                  <h2 class="font-bold" :style="mapHeadingStyle(block)">{{ block.data.heading }}</h2>
+                                  <p :style="mapDescriptionStyle(block)">{{ block.data.description }}</p>
+                                  <div class="space-y-3 text-sm">
+                                    <div class="flex items-center gap-2" :style="mapContactRowStyle(block)">
+                                      <i class="fa-solid fa-location-dot" :style="mapContactIconStyle(block)"></i>
                                       <span>{{ block.data.address }}</span>
                                     </div>
-                                    <div class="flex items-center space-x-2">
-                                      <i class="fa-solid fa-clock text-orange-500"></i>
+                                    <div class="flex items-center gap-2" :style="mapContactRowStyle(block)">
+                                      <i class="fa-solid fa-clock" :style="mapContactIconStyle(block)"></i>
                                       <span>{{ block.data.workHours }}</span>
                                     </div>
-                                    <div class="flex items-center space-x-2">
-                                      <i class="fa-solid fa-phone text-orange-500"></i>
+                                    <div class="flex items-center gap-2" :style="mapContactRowStyle(block)">
+                                      <i class="fa-solid fa-phone" :style="mapContactIconStyle(block)"></i>
                                       <span>{{ block.data.phone }}</span>
                                     </div>
+                                  </div>
+                                  <div v-if="block.data.buttonVisible" :style="blockButtonWrapperStyle(block.data)">
+                                    <button
+                                      :class="blockButtonClass(block.data)"
+                                      :style="blockButtonStyle(block.data, { background: '#f97316', textColor: '#ffffff', secondaryBackground: '#ffffff', secondaryText: '#111827', shadow: block.data.buttonShadow || '0 18px 40px rgba(249,115,22,0.35)' })"
+                                    >
+                                      <span>{{ block.data.buttonText || 'Позвонить нам' }}</span>
+                                      <i class="fa-solid fa-phone"></i>
+                                    </button>
                                   </div>
                                 </div>
                               </div>
@@ -2114,24 +1334,80 @@
         };
       }
 
-      function heroImageProps(element) {
-        const data = element.data || {};
-        return {
-          src: data.src || 'https://images.unsplash.com/photo-1607301405418-780ee5e6dd10',
-          alt: data.alt || 'Изображение',
-          style: {
-            width: asCssSize(data.width, '320px'),
-            height: data.height ? asCssSize(data.height, 'auto') : 'auto',
-            borderRadius: asCssSize(data.borderRadius, '16px'),
-            objectFit: data.objectFit || 'cover',
-            boxShadow: data.boxShadow || '0 25px 60px rgba(15,23,42,0.35)',
-            borderWidth: asCssSize(data.borderWidth, '0px'),
-            borderStyle: 'solid',
-            borderColor: data.borderColor || 'rgba(255,255,255,0.2)',
-            backgroundColor: data.backgroundColor || 'transparent'
-          }
-        };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      function deliveryLayoutClass(block) {
+        const layout = block?.data?.layout || 'two-column';
+        if (layout === 'stacked') {
+          return 'flex flex-col gap-10';
+        }
+        return 'grid lg:grid-cols-2 gap-10 items-start';
       }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
       function setDevice(device) {
         canvas.device = device;
@@ -2470,40 +1746,8 @@
         nextTick(scheduleSelectionOverlay);
       }
 
-      function asCssSize(value, fallback) {
-        if (value === null || value === undefined) {
-          return fallback;
-        }
-        const trimmed = String(value).trim();
-        if (!trimmed) {
-          return fallback;
-        }
-        if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
-          return `${trimmed}px`;
-        }
-        return trimmed;
-      }
 
-      function parseCssNumber(value, fallback = 0) {
-        if (value === null || value === undefined) {
-          return fallback;
-        }
-        const match = String(value).match(/-?\d+(\.\d+)?/);
-        return match ? Number(match[0]) : fallback;
-      }
 
-      function clampNumber(value, min, max) {
-        if (!Number.isFinite(value)) {
-          return min;
-        }
-        if (value < min) {
-          return min;
-        }
-        if (value > max) {
-          return max;
-        }
-        return value;
-      }
 
       function getElementKey(blockId, elementId) {
         return `${blockId}:${elementId}`;
@@ -2596,148 +1840,14 @@
         scheduleSelectionOverlay();
       }
 
-      function heroWrapperStyle(block) {
-        const data = block.data || {};
-        const layout = data.layout || 'split';
-        const heightValue = layout === 'freeform'
-          ? asCssSize(data.freeformHeight || data.minHeight, '640px')
-          : asCssSize(data.minHeight, '560px');
-        return {
-          minHeight: heightValue,
-          padding: `${asCssSize(data.contentPaddingY, '120px')} ${asCssSize(data.contentPaddingX, '96px')}`,
-          position: 'relative'
-        };
-      }
 
-      function heroBackgroundStyle(block) {
-        const data = block.data || {};
-        const image = data.backgroundImage ? `url(${data.backgroundImage})` : 'none';
-        return {
-          backgroundImage: image,
-          backgroundPosition: data.backgroundPosition || 'center center',
-          backgroundSize: data.backgroundSize || 'cover',
-          backgroundRepeat: data.backgroundRepeat || 'no-repeat'
-        };
-      }
 
-      function heroOverlayStyle(block) {
-        const data = block.data || {};
-        const styles = {
-          background: data.overlayColor || 'rgba(17, 24, 39, 0.55)'
-        };
-        const blurValue = parseFloat(data.overlayBlur);
-        if (!Number.isNaN(blurValue) && blurValue > 0) {
-          styles.backdropFilter = `blur(${blurValue}px)`;
-        }
-        return styles;
-      }
 
-      function heroContainerClasses(block) {
-        const data = block.data || {};
-        const layout = data.layout || 'split';
-        if (layout === 'split') {
-          const classes = ['relative', 'grid', 'items-center', 'w-full'];
-          if (data.showRightImage) {
-            classes.push('lg:grid-cols-2');
-          } else {
-            classes.push('grid-cols-1');
-          }
-          return classes.join(' ');
-        }
-        if (layout === 'freeform') {
-          return 'relative flex flex-col w-full';
-        }
-        return 'relative flex flex-col items-center w-full';
-      }
 
-      function heroContainerStyle(block) {
-        const data = block.data || {};
-        const layout = data.layout || 'split';
-        if (layout === 'freeform') {
-          return {
-            gap: '0px',
-            position: 'relative',
-            width: '100%'
-          };
-        }
-        return {
-          gap: asCssSize(data.contentGap, '40px')
-        };
-      }
 
-      function heroContentColumnClasses(block) {
-        const data = block.data || {};
-        const layout = data.layout || 'split';
-        if (layout === 'freeform') {
-          return 'relative w-full min-h-[320px]';
-        }
-        const classes = ['space-y-4', 'w-full'];
-        if (layout === 'split') {
-          classes.push('text-left');
-          if (data.imageSide === 'left' && data.showRightImage) {
-            classes.push('lg:order-2');
-          }
-        } else {
-          classes.push('mx-auto', 'text-center');
-          if (layout === 'spotlight') {
-            classes.push('order-2');
-          }
-        }
-        return classes.join(' ');
-      }
 
-      function heroContentStyle(block) {
-        const data = block.data || {};
-        const style = {
-          maxWidth: asCssSize(data.contentMaxWidth, '620px'),
-          width: '100%'
-        };
-        if (data.layout === 'freeform') {
-          style.position = 'relative';
-          style.minHeight = asCssSize(data.freeformHeight || data.minHeight, '640px');
-        } else if (data.layout && data.layout !== 'split') {
-          style.marginLeft = 'auto';
-          style.marginRight = 'auto';
-        }
-        return style;
-      }
 
-      function heroMediaWrapperClasses(block) {
-        const data = block.data || {};
-        if (!data.showRightImage) {
-          return 'hidden';
-        }
-        const layout = data.layout || 'split';
-        if (layout === 'freeform') {
-          return 'hidden';
-        }
-        if (layout === 'split') {
-          const classes = ['hidden', 'lg:flex', 'items-center', 'justify-center'];
-          if (data.imageSide === 'left') {
-            classes.push('lg:order-1');
-          }
-          return classes.join(' ');
-        }
-        if (layout === 'spotlight') {
-          return 'flex justify-center order-1 w-full mb-10';
-        }
-        return 'flex justify-center w-full mt-10';
-      }
 
-      function heroFeatureIconWrapperStyle(element) {
-        const data = element.data || {};
-        let borderRadius = '9999px';
-        if (data.iconShape === 'square') {
-          borderRadius = '12px';
-        } else if (data.iconShape === 'rounded') {
-          borderRadius = '18px';
-        }
-        return {
-          backgroundColor: data.iconBackground || 'rgba(249, 115, 22, 0.12)',
-          color: data.iconColor || '#f97316',
-          borderRadius
-        };
-      }
 
       function handleWindowResize() {
         scheduleSelectionOverlay();
@@ -3161,7 +2271,74 @@
         heroContentColumnClasses,
         heroContentStyle,
         heroMediaWrapperClasses,
-        heroFeatureIconWrapperStyle
+        heroFeatureIconWrapperStyle,
+        sectionBackgroundStyle,
+        sectionOverlayStyle,
+        blockButtonWrapperStyle,
+        blockButtonClass,
+        blockButtonStyle,
+        categoriesSectionStyle,
+        categoriesOverlayStyle,
+        categoriesHeaderStyle,
+        categoriesHeadingStyle,
+        categoriesSubheadingStyle,
+        categoriesDescriptionStyle,
+        categoriesGridStyle,
+        categoriesCardStyle,
+        categoriesIconWrapperStyle,
+        categoriesCardTitleStyle,
+        categoriesCardDescriptionStyle,
+        menuSectionStyle,
+        menuOverlayStyle,
+        menuHeaderStyle,
+        menuHeadingStyle,
+        menuDescriptionStyle,
+        menuFilterSurfaceStyle,
+        menuTabsWrapperStyle,
+        menuActiveTabStyle,
+        menuTabStyle,
+        menuGridStyle,
+        menuCardStyle,
+        menuCardImageStyle,
+        menuCardTitleStyle,
+        menuCardDescriptionStyle,
+        menuPriceStyle,
+        menuTagStyle,
+        deliverySectionStyle,
+        deliveryOverlayStyle,
+        deliveryLayoutClass,
+        deliveryTextColumnStyle,
+        deliveryHeadingStyle,
+        deliveryDescriptionStyle,
+        deliveryFeatureIconStyle,
+        deliveryFeatureTextStyle,
+        deliveryContactsStyle,
+        deliveryTrackingCardStyle,
+        deliveryTrackingBarStyle,
+        deliveryTrackingTitleStyle,
+        deliveryTrackingDescriptionStyle,
+        deliveryTrackingProgressStyle,
+        reviewsSectionStyle,
+        reviewsOverlayStyle,
+        reviewsHeaderStyle,
+        reviewsHeadingStyle,
+        reviewsDescriptionStyle,
+        reviewsGridStyle,
+        reviewsCardStyle,
+        reviewsAvatarStyle,
+        reviewsCardTitleStyle,
+        reviewsCardSubtitleStyle,
+        reviewsRatingStyle,
+        reviewsQuoteStyle,
+        mapSectionStyle,
+        mapOverlayStyle,
+        mapFrameStyle,
+        mapIframeStyle,
+        mapInfoCardStyle,
+        mapHeadingStyle,
+        mapDescriptionStyle,
+        mapContactRowStyle,
+        mapContactIconStyle
       };
     }
   };

--- a/sushi-store/client/modules/siteBuilder/blocks/categories.js
+++ b/sushi-store/client/modules/siteBuilder/blocks/categories.js
@@ -1,0 +1,186 @@
+// Block definition: categories
+(function(){
+  window.SiteBuilderBlocks = window.SiteBuilderBlocks || {};
+  window.SiteBuilderBlocks['categories'] = {
+      name: 'Категории',
+      icon: 'fa-solid fa-tags',
+      defaultData: () => ({
+        heading: 'Категории и блюда',
+        subheading: 'которые вы нигде не найдете',
+        description: 'Уникальные подборки от наших шефов',
+        backgroundMode: 'solid',
+        backgroundColor: '#f9f4e5',
+        backgroundGradient: 'linear-gradient(135deg, #fef3c7 0%, #fde68a 100%)',
+        backgroundImage: '',
+        backgroundPosition: 'center center',
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+        overlayColor: '',
+        overlayBlur: '0px',
+        sectionPaddingY: '64px',
+        sectionPaddingX: '40px',
+        sectionBorderRadius: '0px',
+        sectionShadow: '',
+        textAlign: 'center',
+        headingColor: '#111827',
+        headingFontSize: '40px',
+        headingFontWeight: '700',
+        headingFontFamily: '',
+        subheadingColor: '#f97316',
+        subheadingFontSize: '20px',
+        subheadingFontWeight: '600',
+        descriptionColor: '#4b5563',
+        descriptionFontSize: '18px',
+        descriptionMaxWidth: '720px',
+        cardBackground: '#ffffff',
+        cardTextColor: '#1f2937',
+        cardDescriptionColor: '#6b7280',
+        cardBorderRadius: '24px',
+        cardShadow: '0 20px 45px rgba(15,23,42,0.08)',
+        cardBorderColor: 'rgba(255,255,255,0)',
+        cardPadding: '28px',
+        cardGap: '24px',
+        cardMinWidth: '240px',
+        cardIconBackground: '#f97316',
+        cardIconColor: '#ffffff',
+        cardIconShape: 'circle',
+        cardIconSize: '80px',
+        cardHoverLift: true,
+        cardHoverShadow: '0 24px 55px rgba(249,115,22,0.25)',
+        buttonVisible: true,
+        buttonText: 'Все категории',
+        buttonStyle: 'secondary',
+        buttonAction: 'link',
+        buttonLink: '/catalog',
+        buttonBackground: '#111827',
+        buttonTextColor: '#ffffff',
+        buttonBorderRadius: '999px',
+        buttonAlign: 'center',
+        buttonShadow: '0 16px 40px rgba(15,23,42,0.18)'
+      }),
+      inspector: [
+        {
+          label: 'Контент',
+          fields: [
+            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Категории и блюда' },
+            { key: 'subheading', label: 'Подзаголовок', type: 'text', placeholder: 'которые вы нигде не найдете' },
+            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Опишите секцию' }
+          ]
+        },
+        {
+          label: 'Фон и отступы',
+          fields: [
+            {
+              key: 'backgroundMode',
+              label: 'Тип фона',
+              type: 'select',
+              options: [
+                { value: 'solid', label: 'Цвет' },
+                { value: 'gradient', label: 'Градиент' },
+                { value: 'image', label: 'Изображение' }
+              ]
+            },
+            { key: 'backgroundColor', label: 'Фон блока', type: 'color' },
+            { key: 'backgroundGradient', label: 'CSS градиент', type: 'text', placeholder: 'linear-gradient(...)' },
+            { key: 'backgroundImage', label: 'Фоновое изображение', type: 'image' },
+            { key: 'backgroundPosition', label: 'Позиция фона', type: 'text', placeholder: 'center center' },
+            { key: 'backgroundSize', label: 'Размер фона', type: 'text', placeholder: 'cover' },
+            { key: 'backgroundRepeat', label: 'Повторение', type: 'text', placeholder: 'no-repeat' },
+            { key: 'overlayColor', label: 'Цвет оверлея', type: 'color' },
+            { key: 'overlayBlur', label: 'Размытие оверлея', type: 'text', placeholder: '0px' },
+            { key: 'sectionPaddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '64px' },
+            { key: 'sectionPaddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '40px' },
+            { key: 'sectionBorderRadius', label: 'Скругление секции', type: 'text', placeholder: '0px' },
+            { key: 'sectionShadow', label: 'Тень секции', type: 'text', placeholder: '0 20px 50px rgba(...)' }
+          ]
+        },
+        {
+          label: 'Заголовки',
+          fields: [
+            { key: 'textAlign', label: 'Выравнивание', type: 'select', options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ] },
+            { key: 'headingColor', label: 'Цвет заголовка', type: 'color' },
+            { key: 'headingFontSize', label: 'Размер заголовка', type: 'text', placeholder: '40px' },
+            { key: 'headingFontWeight', label: 'Начертание заголовка', type: 'text', placeholder: '700' },
+            { key: 'headingFontFamily', label: 'Шрифт заголовка', type: 'text', placeholder: 'Manrope, sans-serif' },
+            { key: 'subheadingColor', label: 'Цвет подзаголовка', type: 'color' },
+            { key: 'subheadingFontSize', label: 'Размер подзаголовка', type: 'text', placeholder: '20px' },
+            { key: 'subheadingFontWeight', label: 'Начертание подзаголовка', type: 'text', placeholder: '600' },
+            { key: 'descriptionColor', label: 'Цвет описания', type: 'color' },
+            { key: 'descriptionFontSize', label: 'Размер описания', type: 'text', placeholder: '18px' },
+            { key: 'descriptionMaxWidth', label: 'Макс. ширина описания', type: 'text', placeholder: '720px' }
+          ]
+        },
+        {
+          label: 'Карточки',
+          fields: [
+            { key: 'cardBackground', label: 'Фон карточек', type: 'color' },
+            { key: 'cardTextColor', label: 'Цвет заголовка карточки', type: 'color' },
+            { key: 'cardDescriptionColor', label: 'Цвет описания карточки', type: 'color' },
+            { key: 'cardBorderRadius', label: 'Скругление карточек', type: 'text', placeholder: '24px' },
+            { key: 'cardShadow', label: 'Тень карточек', type: 'text', placeholder: '0 20px 45px rgba(...)' },
+            { key: 'cardBorderColor', label: 'Цвет границы', type: 'color' },
+            { key: 'cardPadding', label: 'Внутренние отступы', type: 'text', placeholder: '28px' },
+            { key: 'cardGap', label: 'Расстояние между карточками', type: 'text', placeholder: '24px' },
+            { key: 'cardMinWidth', label: 'Мин. ширина карточки', type: 'text', placeholder: '240px' },
+            { key: 'cardIconBackground', label: 'Фон иконки', type: 'color' },
+            { key: 'cardIconColor', label: 'Цвет иконки', type: 'color' },
+            {
+              key: 'cardIconShape',
+              label: 'Форма иконки',
+              type: 'select',
+              options: [
+                { value: 'circle', label: 'Круг' },
+                { value: 'rounded', label: 'Скруглённый квадрат' },
+                { value: 'square', label: 'Квадрат' }
+              ]
+            },
+            { key: 'cardIconSize', label: 'Размер иконки', type: 'text', placeholder: '80px' },
+            { key: 'cardHoverLift', label: 'Поднимать при наведении', type: 'toggle' },
+            { key: 'cardHoverShadow', label: 'Тень при наведении', type: 'text', placeholder: '0 24px 55px rgba(...)' }
+          ]
+        },
+        {
+          label: 'Кнопка',
+          fields: [
+            { key: 'buttonVisible', label: 'Показывать кнопку', type: 'toggle' },
+            { key: 'buttonText', label: 'Текст кнопки', type: 'text', placeholder: 'Все категории' },
+            {
+              key: 'buttonStyle',
+              label: 'Стиль',
+              type: 'select',
+              options: [
+                { value: 'primary', label: 'Основная' },
+                { value: 'secondary', label: 'Вторичная' },
+                { value: 'outline', label: 'Контурная' },
+                { value: 'link', label: 'Ссылка' }
+              ]
+            },
+            {
+              key: 'buttonAction',
+              label: 'Действие',
+              type: 'select',
+              options: [
+                { value: 'scrollMenu', label: 'Прокрутка к меню' },
+                { value: 'openCart', label: 'Открыть корзину' },
+                { value: 'link', label: 'Ссылка' }
+              ]
+            },
+            { key: 'buttonLink', label: 'Ссылка', type: 'text', placeholder: '/catalog' },
+            { key: 'buttonBackground', label: 'Фон кнопки', type: 'color' },
+            { key: 'buttonTextColor', label: 'Цвет текста', type: 'color' },
+            { key: 'buttonBorderRadius', label: 'Скругление', type: 'text', placeholder: '999px' },
+            { key: 'buttonAlign', label: 'Выравнивание', type: 'select', options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ] },
+            { key: 'buttonShadow', label: 'Тень кнопки', type: 'text', placeholder: '0 16px 40px rgba(...)' }
+          ]
+        }
+      ]
+    };
+})();

--- a/sushi-store/client/modules/siteBuilder/blocks/delivery.js
+++ b/sushi-store/client/modules/siteBuilder/blocks/delivery.js
@@ -1,0 +1,190 @@
+// Block definition: delivery
+(function(){
+  window.SiteBuilderBlocks = window.SiteBuilderBlocks || {};
+  window.SiteBuilderBlocks['delivery'] = {
+      name: 'Доставка',
+      icon: 'fa-solid fa-truck-fast',
+      defaultData: () => ({
+        heading: 'Быстрая доставка',
+        description: 'Привезём заказ за 30 минут или подарим ролл',
+        features: [
+          'Бесплатная доставка от 1500 ₽',
+          'Прозрачный трекинг курьера',
+          'Термосумки для горячих блюд'
+        ],
+        backgroundMode: 'solid',
+        backgroundColor: '#fff7ed',
+        backgroundGradient: 'linear-gradient(135deg, #fff7ed 0%, #fde68a 100%)',
+        backgroundImage: '',
+        backgroundPosition: 'center center',
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+        overlayColor: '',
+        overlayBlur: '0px',
+        sectionPaddingY: '80px',
+        sectionPaddingX: '40px',
+        sectionBorderRadius: '0px',
+        sectionShadow: '',
+        headingColor: '#111827',
+        headingFontSize: '36px',
+        headingFontWeight: '700',
+        headingFontFamily: '',
+        textColor: '#4b5563',
+        layout: 'two-column',
+        illustrationImage: '',
+        showTrackingCard: true,
+        trackingTitle: 'Трекинг курьера',
+        trackingDescription: 'Курьер уже рядом – доставит заказ в течение 10 минут',
+        trackingProgress: 75,
+        cardBackground: '#ffffff',
+        cardBorderRadius: '24px',
+        cardShadow: '0 20px 50px rgba(15,23,42,0.1)',
+        featureIconBackground: '#f97316',
+        featureIconColor: '#ffffff',
+        featureIconShape: 'circle',
+        featureTextColor: '#1f2937',
+        contactPhone: '+7 (900) 000-00-00',
+        minOrder: '1500',
+        contactTextColor: '#4b5563',
+        buttonVisible: true,
+        buttonText: 'Условия доставки',
+        buttonStyle: 'secondary',
+        buttonAction: 'link',
+        buttonLink: '/delivery',
+        buttonBackground: '#111827',
+        buttonTextColor: '#ffffff',
+        buttonBorderRadius: '14px',
+        buttonAlign: 'left',
+        buttonShadow: '0 16px 36px rgba(15,23,42,0.18)'
+      }),
+      inspector: [
+        {
+          label: 'Контент',
+          fields: [
+            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Быстрая доставка' },
+            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Расскажите об условиях доставки' }
+          ]
+        },
+        {
+          label: 'Фон и отступы',
+          fields: [
+            {
+              key: 'backgroundMode',
+              label: 'Тип фона',
+              type: 'select',
+              options: [
+                { value: 'solid', label: 'Цвет' },
+                { value: 'gradient', label: 'Градиент' },
+                { value: 'image', label: 'Изображение' }
+              ]
+            },
+            { key: 'backgroundColor', label: 'Фон блока', type: 'color' },
+            { key: 'backgroundGradient', label: 'CSS градиент', type: 'text', placeholder: 'linear-gradient(...)' },
+            { key: 'backgroundImage', label: 'Фоновое изображение', type: 'image' },
+            { key: 'backgroundPosition', label: 'Позиция фона', type: 'text', placeholder: 'center center' },
+            { key: 'backgroundSize', label: 'Размер фона', type: 'text', placeholder: 'cover' },
+            { key: 'backgroundRepeat', label: 'Повторение', type: 'text', placeholder: 'no-repeat' },
+            { key: 'overlayColor', label: 'Цвет оверлея', type: 'color' },
+            { key: 'overlayBlur', label: 'Размытие оверлея', type: 'text', placeholder: '0px' },
+            { key: 'sectionPaddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '80px' },
+            { key: 'sectionPaddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '40px' },
+            { key: 'sectionBorderRadius', label: 'Скругление секции', type: 'text', placeholder: '0px' },
+            { key: 'sectionShadow', label: 'Тень секции', type: 'text', placeholder: '0 20px 50px rgba(...)' }
+          ]
+        },
+        {
+          label: 'Заголовок и текст',
+          fields: [
+            { key: 'headingColor', label: 'Цвет заголовка', type: 'color' },
+            { key: 'headingFontSize', label: 'Размер заголовка', type: 'text', placeholder: '36px' },
+            { key: 'headingFontWeight', label: 'Начертание заголовка', type: 'text', placeholder: '700' },
+            { key: 'headingFontFamily', label: 'Шрифт заголовка', type: 'text', placeholder: 'Manrope, sans-serif' },
+            { key: 'textColor', label: 'Цвет описаний', type: 'color' },
+            {
+              key: 'layout',
+              label: 'Макет',
+              type: 'select',
+              options: [
+                { value: 'two-column', label: 'Две колонки' },
+                { value: 'stacked', label: 'Столбцом' },
+                { value: 'spotlight', label: 'С иллюстрацией сверху' }
+              ]
+            },
+            { key: 'illustrationImage', label: 'Изображение/иллюстрация', type: 'image' }
+          ]
+        },
+        {
+          label: 'Преимущества',
+          fields: [
+            { key: 'features', label: 'Список преимуществ', type: 'list', placeholder: 'Каждое с новой строки' },
+            { key: 'featureIconBackground', label: 'Фон иконки', type: 'color' },
+            { key: 'featureIconColor', label: 'Цвет иконки', type: 'color' },
+            {
+              key: 'featureIconShape',
+              label: 'Форма иконки',
+              type: 'select',
+              options: [
+                { value: 'circle', label: 'Круг' },
+                { value: 'rounded', label: 'Скруглённый квадрат' },
+                { value: 'square', label: 'Квадрат' }
+              ]
+            },
+            { key: 'featureTextColor', label: 'Цвет текста преимуществ', type: 'color' }
+          ]
+        },
+        {
+          label: 'Трекинг и карточка',
+          fields: [
+            { key: 'showTrackingCard', label: 'Показывать карточку трекинга', type: 'toggle' },
+            { key: 'trackingTitle', label: 'Заголовок трекинга', type: 'text', placeholder: 'Трекинг курьера' },
+            { key: 'trackingDescription', label: 'Описание трекинга', type: 'textarea', rows: 3 },
+            { key: 'trackingProgress', label: 'Прогресс (%)', type: 'text', placeholder: '75' },
+            { key: 'cardBackground', label: 'Фон карточки', type: 'color' },
+            { key: 'cardBorderRadius', label: 'Скругление карточки', type: 'text', placeholder: '24px' },
+            { key: 'cardShadow', label: 'Тень карточки', type: 'text', placeholder: '0 20px 50px rgba(...)' }
+          ]
+        },
+        {
+          label: 'Контакты и CTA',
+          fields: [
+            { key: 'contactPhone', label: 'Телефон курьера', type: 'text', placeholder: '+7 (900) 000-00-00' },
+            { key: 'minOrder', label: 'Минимальный заказ', type: 'text', placeholder: '1500' },
+            { key: 'contactTextColor', label: 'Цвет текста контактов', type: 'color' },
+            { key: 'buttonVisible', label: 'Показывать кнопку', type: 'toggle' },
+            { key: 'buttonText', label: 'Текст кнопки', type: 'text', placeholder: 'Условия доставки' },
+            {
+              key: 'buttonStyle',
+              label: 'Стиль',
+              type: 'select',
+              options: [
+                { value: 'primary', label: 'Основная' },
+                { value: 'secondary', label: 'Вторичная' },
+                { value: 'outline', label: 'Контурная' },
+                { value: 'link', label: 'Ссылка' }
+              ]
+            },
+            {
+              key: 'buttonAction',
+              label: 'Действие',
+              type: 'select',
+              options: [
+                { value: 'scrollMenu', label: 'Прокрутка к меню' },
+                { value: 'openCart', label: 'Открыть корзину' },
+                { value: 'link', label: 'Ссылка' }
+              ]
+            },
+            { key: 'buttonLink', label: 'Ссылка', type: 'text', placeholder: '/delivery' },
+            { key: 'buttonBackground', label: 'Фон кнопки', type: 'color' },
+            { key: 'buttonTextColor', label: 'Цвет текста', type: 'color' },
+            { key: 'buttonBorderRadius', label: 'Скругление', type: 'text', placeholder: '14px' },
+            { key: 'buttonAlign', label: 'Выравнивание', type: 'select', options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ] },
+            { key: 'buttonShadow', label: 'Тень кнопки', type: 'text', placeholder: '0 16px 36px rgba(...)' }
+          ]
+        }
+      ]
+    };
+})();

--- a/sushi-store/client/modules/siteBuilder/blocks/hero.js
+++ b/sushi-store/client/modules/siteBuilder/blocks/hero.js
@@ -1,0 +1,165 @@
+// Block definition: hero
+(function(){
+  window.SiteBuilderBlocks = window.SiteBuilderBlocks || {};
+  window.SiteBuilderBlocks['hero'] = {
+        name: 'Hero-блок',
+        icon: 'fa-solid fa-fire',
+        defaultData: () => ({
+          heading: 'Быстро и вкусно',
+          subheading: 'Попробуйте наши фирменные суши',
+          description: 'Свежие роллы, пицца и десерты с доставкой за 30 минут.',
+          buttonText: 'Выбрать блюда',
+          buttonStyle: 'primary',
+          buttonAction: 'scrollMenu',
+          buttonLink: '',
+          backgroundImage: 'https://images.unsplash.com/photo-1579952363873-27d3bfad9c0d',
+          previewImage: 'https://images.unsplash.com/photo-1607301405418-780ee5e6dd10',
+          imageSide: 'right',
+          showRightImage: true,
+          waveEnabled: true,
+          waveColor: '#f9f4e5',
+          overlayColor: 'rgba(17, 24, 39, 0.55)',
+          contentMaxWidth: '620px',
+          contentPaddingX: '96px',
+          contentPaddingY: '120px',
+          contentGap: '40px',
+          minHeight: '640px',
+          freeformHeight: '640px',
+          layout: 'split',
+          backgroundPosition: 'center center',
+          backgroundSize: 'cover',
+          backgroundRepeat: 'no-repeat',
+          overlayBlur: '0',
+          elements: [
+            {
+              type: 'heading',
+              data: {
+                text: 'Быстро и вкусно',
+                level: 'h1',
+                fontSize: 'text-5xl',
+                color: '#ffffff',
+                align: 'left',
+                marginTop: '0px',
+                marginBottom: '16px'
+              }
+            },
+            {
+              type: 'subheading',
+              data: {
+                text: 'Попробуйте фирменные роллы сегодня',
+                fontSize: 'text-2xl',
+                color: '#fbbf24',
+                align: 'left',
+                marginTop: '0px',
+                marginBottom: '12px'
+              }
+            },
+            {
+              type: 'paragraph',
+              data: {
+                text: 'Комбинируйте суши, пиццу и десерты. Мы доставим всё тёплым и свежим.',
+                fontSize: 'text-lg',
+                color: '#f9fafb',
+                align: 'left',
+                marginTop: '0px',
+                marginBottom: '20px'
+              }
+            },
+            {
+              type: 'button',
+              data: {
+                text: 'Собрать заказ',
+                style: 'primary',
+                action: 'scrollMenu',
+                align: 'left',
+                marginTop: '0px',
+                marginBottom: '0px'
+              }
+            }
+          ]
+        }),
+        inspector: [
+          {
+            label: 'Контент',
+            fields: [
+              { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Быстро и вкусно' },
+              { key: 'subheading', label: 'Подзаголовок', type: 'text', placeholder: 'Попробуйте наши фирменные суши' },
+              { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Коротко о предложении' }
+            ]
+          },
+          {
+            label: 'Кнопка',
+            fields: [
+              { key: 'buttonText', label: 'Текст кнопки', type: 'text', placeholder: 'Выбрать блюда' },
+              {
+                key: 'buttonStyle',
+                label: 'Стиль кнопки',
+                type: 'select',
+                options: [
+                  { value: 'primary', label: 'Основная' },
+                  { value: 'secondary', label: 'Вторичная' }
+                ]
+              },
+              {
+                key: 'buttonAction',
+                label: 'Действие',
+                type: 'select',
+                options: [
+                  { value: 'scrollMenu', label: 'Прокрутка к меню' },
+                  { value: 'openCart', label: 'Открыть корзину' },
+                  { value: 'link', label: 'Перейти по ссылке' }
+                ]
+              },
+              { key: 'buttonLink', label: 'Ссылка (для действия "Ссылка")', type: 'text', placeholder: 'https://...' }
+            ]
+          },
+          {
+            label: 'Макет',
+            fields: [
+              {
+                key: 'layout',
+                label: 'Расположение',
+                type: 'select',
+                options: [
+                  { value: 'split', label: 'Текст и изображение' },
+                  { value: 'stacked', label: 'Только текст' },
+                  { value: 'spotlight', label: 'Текст над изображением' },
+                  { value: 'freeform', label: 'Свободное расположение' }
+                ]
+              },
+              { key: 'contentMaxWidth', label: 'Ширина контента', type: 'text', placeholder: '620px' },
+              { key: 'contentPaddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '96px' },
+              { key: 'contentPaddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '120px' },
+              { key: 'contentGap', label: 'Отступ между колонками', type: 'text', placeholder: '40px' },
+              { key: 'minHeight', label: 'Минимальная высота', type: 'text', placeholder: '640px' },
+              { key: 'freeformHeight', label: 'Высота для свободного режима', type: 'text', placeholder: '640px' }
+            ]
+          },
+          {
+            label: 'Оформление',
+            fields: [
+              { key: 'backgroundImage', label: 'Фоновое изображение', type: 'image' },
+              { key: 'previewImage', label: 'Изображение справа', type: 'image' },
+              {
+                key: 'imageSide',
+                label: 'Расположение изображения',
+                type: 'select',
+                options: [
+                  { value: 'left', label: 'Слева' },
+                  { value: 'right', label: 'Справа' }
+                ]
+              },
+              { key: 'showRightImage', label: 'Показывать изображение', type: 'toggle' },
+              { key: 'waveEnabled', label: 'Декоративная волна', type: 'toggle' },
+              { key: 'waveColor', label: 'Цвет волны', type: 'color' },
+              { key: 'overlayColor', label: 'Цвет наложения', type: 'color' },
+              { key: 'backgroundPosition', label: 'Позиция фона', type: 'text', placeholder: 'center center' },
+              { key: 'backgroundSize', label: 'Размер фона', type: 'text', placeholder: 'cover' },
+              { key: 'backgroundRepeat', label: 'Повторение фона', type: 'text', placeholder: 'no-repeat' },
+              { key: 'overlayBlur', label: 'Размытие наложения (px)', type: 'text', placeholder: '0' }
+            ]
+          }
+        ],
+        elements: ['heading', 'subheading', 'paragraph', 'button', 'image', 'feature', 'spacer']
+      };
+})();

--- a/sushi-store/client/modules/siteBuilder/blocks/map.js
+++ b/sushi-store/client/modules/siteBuilder/blocks/map.js
@@ -1,0 +1,155 @@
+// Block definition: map
+(function(){
+  window.SiteBuilderBlocks = window.SiteBuilderBlocks || {};
+  window.SiteBuilderBlocks['map'] = {
+      name: 'Карта и контакты',
+      icon: 'fa-solid fa-map-location-dot',
+      defaultData: () => ({
+        heading: 'Зоны доставки',
+        description: 'Нажмите на нужный район, чтобы узнать условия доставки',
+        iframeSrc: 'https://yandex.ru/map-widget/v1/?lang=ru_RU&scroll=true&source=constructor-api&um=constructor%3A1569f1da7d596921cd82db1f441ffc63d2a386db371645fede23dbc26dc86a74',
+        address: 'г. Санкт-Петербург, ул. Суши, 5',
+        workHours: 'Ежедневно 10:00 — 23:00',
+        phone: '+7 (812) 000-00-00',
+        backgroundMode: 'solid',
+        backgroundColor: '#ffffff',
+        backgroundGradient: 'linear-gradient(135deg, #ffffff 0%, #fef2f2 100%)',
+        backgroundImage: '',
+        backgroundPosition: 'center center',
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+        overlayColor: '',
+        overlayBlur: '0px',
+        sectionPaddingY: '80px',
+        sectionPaddingX: '40px',
+        headingColor: '#111827',
+        headingFontSize: '32px',
+        headingFontWeight: '700',
+        headingFontFamily: '',
+        descriptionColor: '#4b5563',
+        descriptionFontSize: '18px',
+        descriptionMaxWidth: '520px',
+        textAlign: 'left',
+        mapHeight: '380px',
+        mapBorderRadius: '24px',
+        mapShadow: '0 20px 45px rgba(15,23,42,0.08)',
+        cardBackground: '#ffffff',
+        cardBorderRadius: '24px',
+        cardShadow: '0 18px 40px rgba(15,23,42,0.08)',
+        cardTextColor: '#1f2937',
+        contactIconColor: '#f97316',
+        contactTextColor: '#4b5563',
+        buttonVisible: true,
+        buttonText: 'Позвонить нам',
+        buttonStyle: 'primary',
+        buttonAction: 'link',
+        buttonLink: 'tel:+79000000000',
+        buttonBackground: '#f97316',
+        buttonTextColor: '#ffffff',
+        buttonBorderRadius: '999px',
+        buttonAlign: 'left',
+        buttonShadow: '0 18px 40px rgba(249,115,22,0.35)'
+      }),
+      inspector: [
+        {
+          label: 'Контент',
+          fields: [
+            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Зоны доставки' },
+            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Опишите как работает доставка' },
+            { key: 'descriptionMaxWidth', label: 'Макс. ширина описания', type: 'text', placeholder: '520px' },
+            { key: 'textAlign', label: 'Выравнивание текста', type: 'select', options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ] }
+          ]
+        },
+        {
+          label: 'Фон и отступы',
+          fields: [
+            {
+              key: 'backgroundMode',
+              label: 'Тип фона',
+              type: 'select',
+              options: [
+                { value: 'solid', label: 'Цвет' },
+                { value: 'gradient', label: 'Градиент' },
+                { value: 'image', label: 'Изображение' }
+              ]
+            },
+            { key: 'backgroundColor', label: 'Фон блока', type: 'color' },
+            { key: 'backgroundGradient', label: 'CSS градиент', type: 'text', placeholder: 'linear-gradient(...)' },
+            { key: 'backgroundImage', label: 'Фоновое изображение', type: 'image' },
+            { key: 'backgroundPosition', label: 'Позиция фона', type: 'text', placeholder: 'center center' },
+            { key: 'backgroundSize', label: 'Размер фона', type: 'text', placeholder: 'cover' },
+            { key: 'backgroundRepeat', label: 'Повторение', type: 'text', placeholder: 'no-repeat' },
+            { key: 'overlayColor', label: 'Цвет оверлея', type: 'color' },
+            { key: 'overlayBlur', label: 'Размытие оверлея', type: 'text', placeholder: '0px' },
+            { key: 'sectionPaddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '80px' },
+            { key: 'sectionPaddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '40px' }
+          ]
+        },
+        {
+          label: 'Карта',
+          fields: [
+            { key: 'iframeSrc', label: 'Ссылка на карту (iframe)', type: 'textarea', rows: 2 },
+            { key: 'mapHeight', label: 'Высота карты', type: 'text', placeholder: '380px' },
+            { key: 'mapBorderRadius', label: 'Скругление карты', type: 'text', placeholder: '24px' },
+            { key: 'mapShadow', label: 'Тень карты', type: 'text', placeholder: '0 20px 45px rgba(...)' }
+          ]
+        },
+        {
+          label: 'Контакты',
+          fields: [
+            { key: 'address', label: 'Адрес', type: 'text', placeholder: 'г. Санкт-Петербург...' },
+            { key: 'phone', label: 'Телефон', type: 'text', placeholder: '+7 (...)' },
+            { key: 'workHours', label: 'Время работы', type: 'text', placeholder: '10:00 — 23:00' },
+            { key: 'cardBackground', label: 'Фон карточки контактов', type: 'color' },
+            { key: 'cardBorderRadius', label: 'Скругление карточки', type: 'text', placeholder: '24px' },
+            { key: 'cardShadow', label: 'Тень карточки', type: 'text', placeholder: '0 18px 40px rgba(...)' },
+            { key: 'cardTextColor', label: 'Цвет текста карточки', type: 'color' },
+            { key: 'contactIconColor', label: 'Цвет иконок', type: 'color' },
+            { key: 'contactTextColor', label: 'Цвет текста контактов', type: 'color' }
+          ]
+        },
+        {
+          label: 'Кнопка',
+          fields: [
+            { key: 'buttonVisible', label: 'Показывать кнопку', type: 'toggle' },
+            { key: 'buttonText', label: 'Текст кнопки', type: 'text', placeholder: 'Позвонить нам' },
+            {
+              key: 'buttonStyle',
+              label: 'Стиль',
+              type: 'select',
+              options: [
+                { value: 'primary', label: 'Основная' },
+                { value: 'secondary', label: 'Вторичная' },
+                { value: 'outline', label: 'Контурная' },
+                { value: 'link', label: 'Ссылка' }
+              ]
+            },
+            {
+              key: 'buttonAction',
+              label: 'Действие',
+              type: 'select',
+              options: [
+                { value: 'scrollMenu', label: 'Прокрутка к меню' },
+                { value: 'openCart', label: 'Открыть корзину' },
+                { value: 'link', label: 'Ссылка' }
+              ]
+            },
+            { key: 'buttonLink', label: 'Ссылка', type: 'text', placeholder: 'tel:+79000000000' },
+            { key: 'buttonBackground', label: 'Фон кнопки', type: 'color' },
+            { key: 'buttonTextColor', label: 'Цвет текста', type: 'color' },
+            { key: 'buttonBorderRadius', label: 'Скругление', type: 'text', placeholder: '999px' },
+            { key: 'buttonAlign', label: 'Выравнивание', type: 'select', options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ] },
+            { key: 'buttonShadow', label: 'Тень кнопки', type: 'text', placeholder: '0 18px 40px rgba(...)' }
+          ]
+        }
+      ]
+    };
+})();

--- a/sushi-store/client/modules/siteBuilder/blocks/menu.js
+++ b/sushi-store/client/modules/siteBuilder/blocks/menu.js
@@ -1,0 +1,183 @@
+// Block definition: menu
+(function(){
+  window.SiteBuilderBlocks = window.SiteBuilderBlocks || {};
+  window.SiteBuilderBlocks['menu'] = {
+      name: 'Меню',
+      icon: 'fa-solid fa-utensils',
+      defaultData: () => ({
+        heading: 'Популярные блюда',
+        description: 'Выберите категорию и сформируйте свой сет',
+        backgroundMode: 'gradient',
+        backgroundColor: '#fff7ed',
+        backgroundGradient: 'linear-gradient(135deg, #fff7ed 0%, #ffe4e6 100%)',
+        backgroundImage: '',
+        backgroundPosition: 'center center',
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+        overlayColor: 'rgba(255,247,237,0.75)',
+        overlayBlur: '0px',
+        sectionPaddingY: '72px',
+        sectionPaddingX: '40px',
+        headingColor: '#111827',
+        headingFontSize: '36px',
+        headingFontWeight: '700',
+        headingFontFamily: '',
+        descriptionColor: '#4b5563',
+        descriptionFontSize: '18px',
+        descriptionMaxWidth: '640px',
+        textAlign: 'center',
+        showSearch: true,
+        showFilters: true,
+        showCategoryTabs: true,
+        highlightHits: true,
+        cardsPerRow: '3',
+        cardMinWidth: '260px',
+        cardBackground: '#ffffff',
+        cardTextColor: '#1f2937',
+        cardDescriptionColor: '#6b7280',
+        cardBorderRadius: '24px',
+        cardShadow: '0 18px 40px rgba(15,23,42,0.08)',
+        cardBorderColor: 'rgba(255,255,255,0)',
+        cardImageHeight: '180px',
+        priceColor: '#f97316',
+        tagTextColor: '#f97316',
+        tagBackground: 'rgba(249,115,22,0.12)',
+        filtersBackground: '#ffffff',
+        filtersTextColor: '#1f2937',
+        filtersShadow: '0 14px 30px rgba(15,23,42,0.08)',
+        buttonVisible: false,
+        buttonText: 'Открыть меню',
+        buttonStyle: 'primary',
+        buttonAction: 'scrollMenu',
+        buttonLink: '',
+        buttonBackground: '#f97316',
+        buttonTextColor: '#ffffff',
+        buttonBorderRadius: '999px',
+        buttonAlign: 'center',
+        buttonShadow: '0 16px 40px rgba(249,115,22,0.35)'
+      }),
+      inspector: [
+        {
+          label: 'Контент',
+          fields: [
+            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Популярные блюда' },
+            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Выберите категорию и сформируйте свой сет' }
+          ]
+        },
+        {
+          label: 'Фон и отступы',
+          fields: [
+            {
+              key: 'backgroundMode',
+              label: 'Тип фона',
+              type: 'select',
+              options: [
+                { value: 'solid', label: 'Цвет' },
+                { value: 'gradient', label: 'Градиент' },
+                { value: 'image', label: 'Изображение' }
+              ]
+            },
+            { key: 'backgroundColor', label: 'Фон блока', type: 'color' },
+            { key: 'backgroundGradient', label: 'CSS градиент', type: 'text', placeholder: 'linear-gradient(...)' },
+            { key: 'backgroundImage', label: 'Фоновое изображение', type: 'image' },
+            { key: 'backgroundPosition', label: 'Позиция фона', type: 'text', placeholder: 'center center' },
+            { key: 'backgroundSize', label: 'Размер фона', type: 'text', placeholder: 'cover' },
+            { key: 'backgroundRepeat', label: 'Повторение', type: 'text', placeholder: 'no-repeat' },
+            { key: 'overlayColor', label: 'Цвет оверлея', type: 'color' },
+            { key: 'overlayBlur', label: 'Размытие оверлея', type: 'text', placeholder: '0px' },
+            { key: 'sectionPaddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '72px' },
+            { key: 'sectionPaddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '40px' }
+          ]
+        },
+        {
+          label: 'Заголовки и описание',
+          fields: [
+            { key: 'textAlign', label: 'Выравнивание', type: 'select', options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ] },
+            { key: 'headingColor', label: 'Цвет заголовка', type: 'color' },
+            { key: 'headingFontSize', label: 'Размер заголовка', type: 'text', placeholder: '36px' },
+            { key: 'headingFontWeight', label: 'Начертание заголовка', type: 'text', placeholder: '700' },
+            { key: 'headingFontFamily', label: 'Шрифт заголовка', type: 'text', placeholder: 'Manrope, sans-serif' },
+            { key: 'descriptionColor', label: 'Цвет описания', type: 'color' },
+            { key: 'descriptionFontSize', label: 'Размер описания', type: 'text', placeholder: '18px' },
+            { key: 'descriptionMaxWidth', label: 'Макс. ширина описания', type: 'text', placeholder: '640px' }
+          ]
+        },
+        {
+          label: 'Функции',
+          fields: [
+            { key: 'showSearch', label: 'Показывать поиск', type: 'toggle' },
+            { key: 'showFilters', label: 'Показывать фильтры', type: 'toggle' },
+            { key: 'showCategoryTabs', label: 'Вкладки категорий', type: 'toggle' },
+            { key: 'highlightHits', label: 'Подсвечивать хиты', type: 'toggle' },
+            { key: 'cardsPerRow', label: 'Карточек в ряд (превью)', type: 'text', placeholder: '3' }
+          ]
+        },
+        {
+          label: 'Карточки блюд',
+          fields: [
+            { key: 'cardMinWidth', label: 'Мин. ширина карточки', type: 'text', placeholder: '260px' },
+            { key: 'cardBackground', label: 'Фон карточки', type: 'color' },
+            { key: 'cardTextColor', label: 'Цвет названия', type: 'color' },
+            { key: 'cardDescriptionColor', label: 'Цвет описания', type: 'color' },
+            { key: 'cardBorderRadius', label: 'Скругление карточки', type: 'text', placeholder: '24px' },
+            { key: 'cardShadow', label: 'Тень карточки', type: 'text', placeholder: '0 18px 40px rgba(...)' },
+            { key: 'cardBorderColor', label: 'Цвет границы', type: 'color' },
+            { key: 'cardImageHeight', label: 'Высота изображения', type: 'text', placeholder: '180px' },
+            { key: 'priceColor', label: 'Цвет цены', type: 'color' },
+            { key: 'tagTextColor', label: 'Цвет бейджа', type: 'color' },
+            { key: 'tagBackground', label: 'Фон бейджа', type: 'color' }
+          ]
+        },
+        {
+          label: 'Поиск и фильтры',
+          fields: [
+            { key: 'filtersBackground', label: 'Фон панели', type: 'color' },
+            { key: 'filtersTextColor', label: 'Цвет текста', type: 'color' },
+            { key: 'filtersShadow', label: 'Тень панели', type: 'text', placeholder: '0 14px 30px rgba(...)' }
+          ]
+        },
+        {
+          label: 'Кнопка',
+          fields: [
+            { key: 'buttonVisible', label: 'Показывать кнопку', type: 'toggle' },
+            { key: 'buttonText', label: 'Текст кнопки', type: 'text', placeholder: 'Открыть меню' },
+            {
+              key: 'buttonStyle',
+              label: 'Стиль',
+              type: 'select',
+              options: [
+                { value: 'primary', label: 'Основная' },
+                { value: 'secondary', label: 'Вторичная' },
+                { value: 'outline', label: 'Контурная' },
+                { value: 'link', label: 'Ссылка' }
+              ]
+            },
+            {
+              key: 'buttonAction',
+              label: 'Действие',
+              type: 'select',
+              options: [
+                { value: 'scrollMenu', label: 'Прокрутка к меню' },
+                { value: 'openCart', label: 'Открыть корзину' },
+                { value: 'link', label: 'Ссылка' }
+              ]
+            },
+            { key: 'buttonLink', label: 'Ссылка', type: 'text', placeholder: '#menu' },
+            { key: 'buttonBackground', label: 'Фон кнопки', type: 'color' },
+            { key: 'buttonTextColor', label: 'Цвет текста', type: 'color' },
+            { key: 'buttonBorderRadius', label: 'Скругление', type: 'text', placeholder: '999px' },
+            { key: 'buttonAlign', label: 'Выравнивание', type: 'select', options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ] },
+            { key: 'buttonShadow', label: 'Тень кнопки', type: 'text', placeholder: '0 16px 40px rgba(...)' }
+          ]
+        }
+      ]
+    };
+})();

--- a/sushi-store/client/modules/siteBuilder/blocks/reviews.js
+++ b/sushi-store/client/modules/siteBuilder/blocks/reviews.js
@@ -1,0 +1,141 @@
+// Block definition: reviews
+(function(){
+  window.SiteBuilderBlocks = window.SiteBuilderBlocks || {};
+  window.SiteBuilderBlocks['reviews'] = {
+      name: 'Отзывы',
+      icon: 'fa-solid fa-comments',
+      defaultData: () => ({
+        heading: 'Отзывы наших гостей',
+        description: 'Более 1000 довольных клиентов в этом месяце',
+        backgroundMode: 'gradient',
+        backgroundColor: '#fff7ed',
+        backgroundGradient: 'linear-gradient(135deg, #fff7ed 0%, #ffe4e6 100%)',
+        backgroundImage: '',
+        backgroundPosition: 'center center',
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+        overlayColor: 'rgba(255,247,237,0.7)',
+        overlayBlur: '0px',
+        sectionPaddingY: '80px',
+        sectionPaddingX: '40px',
+        headingColor: '#111827',
+        headingFontSize: '36px',
+        headingFontWeight: '700',
+        headingFontFamily: '',
+        descriptionColor: '#4b5563',
+        descriptionFontSize: '18px',
+        descriptionMaxWidth: '640px',
+        textAlign: 'center',
+        layout: 'grid',
+        columns: 3,
+        autoPlay: true,
+        autoPlayInterval: 6000,
+        showArrows: true,
+        showDots: true,
+        cardBackground: '#ffffff',
+        cardTextColor: '#1f2937',
+        cardBorderRadius: '24px',
+        cardShadow: '0 16px 40px rgba(15,23,42,0.08)',
+        cardBorderColor: 'rgba(255,255,255,0)',
+        cardQuoteColor: '#4b5563',
+        ratingColor: '#facc15',
+        avatarBackground: '#fed7aa',
+        avatarShape: 'circle',
+        accentColor: '#f97316'
+      }),
+      inspector: [
+        {
+          label: 'Контент',
+          fields: [
+            { key: 'heading', label: 'Заголовок', type: 'text', placeholder: 'Отзывы наших гостей' },
+            { key: 'description', label: 'Описание', type: 'textarea', rows: 3, placeholder: 'Более 1000 довольных клиентов' }
+          ]
+        },
+        {
+          label: 'Фон и отступы',
+          fields: [
+            {
+              key: 'backgroundMode',
+              label: 'Тип фона',
+              type: 'select',
+              options: [
+                { value: 'solid', label: 'Цвет' },
+                { value: 'gradient', label: 'Градиент' },
+                { value: 'image', label: 'Изображение' }
+              ]
+            },
+            { key: 'backgroundColor', label: 'Фон блока', type: 'color' },
+            { key: 'backgroundGradient', label: 'CSS градиент', type: 'text', placeholder: 'linear-gradient(...)' },
+            { key: 'backgroundImage', label: 'Фоновое изображение', type: 'image' },
+            { key: 'backgroundPosition', label: 'Позиция фона', type: 'text', placeholder: 'center center' },
+            { key: 'backgroundSize', label: 'Размер фона', type: 'text', placeholder: 'cover' },
+            { key: 'backgroundRepeat', label: 'Повторение', type: 'text', placeholder: 'no-repeat' },
+            { key: 'overlayColor', label: 'Цвет оверлея', type: 'color' },
+            { key: 'overlayBlur', label: 'Размытие оверлея', type: 'text', placeholder: '0px' },
+            { key: 'sectionPaddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '80px' },
+            { key: 'sectionPaddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '40px' }
+          ]
+        },
+        {
+          label: 'Заголовки',
+          fields: [
+            { key: 'textAlign', label: 'Выравнивание', type: 'select', options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ] },
+            { key: 'headingColor', label: 'Цвет заголовка', type: 'color' },
+            { key: 'headingFontSize', label: 'Размер заголовка', type: 'text', placeholder: '36px' },
+            { key: 'headingFontWeight', label: 'Начертание заголовка', type: 'text', placeholder: '700' },
+            { key: 'headingFontFamily', label: 'Шрифт заголовка', type: 'text', placeholder: 'Manrope, sans-serif' },
+            { key: 'descriptionColor', label: 'Цвет описания', type: 'color' },
+            { key: 'descriptionFontSize', label: 'Размер описания', type: 'text', placeholder: '18px' },
+            { key: 'descriptionMaxWidth', label: 'Макс. ширина описания', type: 'text', placeholder: '640px' }
+          ]
+        },
+        {
+          label: 'Настройки карусели',
+          fields: [
+            {
+              key: 'layout',
+              label: 'Макет',
+              type: 'select',
+              options: [
+                { value: 'grid', label: 'Сетка' },
+                { value: 'carousel', label: 'Карусель' }
+              ]
+            },
+            { key: 'columns', label: 'Кол-во колонок (превью)', type: 'text', placeholder: '3' },
+            { key: 'autoPlay', label: 'Автопрокрутка', type: 'toggle' },
+            { key: 'autoPlayInterval', label: 'Интервал автопрокрутки (мс)', type: 'text', placeholder: '6000' },
+            { key: 'showArrows', label: 'Показывать стрелки', type: 'toggle' },
+            { key: 'showDots', label: 'Показывать индикаторы', type: 'toggle' }
+          ]
+        },
+        {
+          label: 'Карточки отзывов',
+          fields: [
+            { key: 'cardBackground', label: 'Фон карточки', type: 'color' },
+            { key: 'cardTextColor', label: 'Цвет текста', type: 'color' },
+            { key: 'cardQuoteColor', label: 'Цвет цитаты', type: 'color' },
+            { key: 'ratingColor', label: 'Цвет звёзд', type: 'color' },
+            { key: 'cardBorderRadius', label: 'Скругление карточки', type: 'text', placeholder: '24px' },
+            { key: 'cardShadow', label: 'Тень карточки', type: 'text', placeholder: '0 16px 40px rgba(...)' },
+            { key: 'cardBorderColor', label: 'Цвет границы', type: 'color' },
+            { key: 'avatarBackground', label: 'Фон аватара', type: 'color' },
+            {
+              key: 'avatarShape',
+              label: 'Форма аватара',
+              type: 'select',
+              options: [
+                { value: 'circle', label: 'Круг' },
+                { value: 'rounded', label: 'Скруглённый квадрат' },
+                { value: 'square', label: 'Квадрат' }
+              ]
+            },
+            { key: 'accentColor', label: 'Акцентный цвет', type: 'color' }
+          ]
+        }
+      ]
+    };
+})();

--- a/sushi-store/client/modules/siteBuilder/core.js
+++ b/sushi-store/client/modules/siteBuilder/core.js
@@ -1,0 +1,108 @@
+// Core registries and helpers for the visual site builder
+(function(){
+  const elementRegistry = window.SiteBuilderElements;
+  const blockRegistry = window.SiteBuilderBlocks;
+  const styles = window.SiteBuilderStyles || {};
+
+  if (!elementRegistry) {
+    console.error('SiteBuilder: element registry is missing. Did you load /modules/siteBuilder/elements.js?');
+    return;
+  }
+
+  if (!blockRegistry) {
+    console.error('SiteBuilder: block registry is missing. Did you load the /modules/siteBuilder/blocks/*.js modules?');
+    return;
+  }
+
+  function deepClone(value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function generateId(prefix) {
+    return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
+  }
+
+  function normalizeElement(elementLike) {
+    if (!elementLike) {
+      return null;
+    }
+    const type = elementLike.type || 'paragraph';
+    const definition = elementRegistry[type];
+    if (!definition) {
+      return null;
+    }
+    const base = definition.defaultData ? definition.defaultData() : {};
+    const incoming = elementLike.data || {};
+    return {
+      id: elementLike.id || generateId('element'),
+      type,
+      data: { ...base, ...incoming }
+    };
+  }
+
+  function createBlockInstance(type, source = {}) {
+    const definition = blockRegistry[type];
+    if (!definition) {
+      return null;
+    }
+    const defaults = definition.defaultData ? definition.defaultData() : {};
+    const data = source.data || source || {};
+    const merged = { ...defaults, ...data };
+
+    if (definition.elements) {
+      const elements = Array.isArray(data.elements) ? data.elements : defaults.elements;
+      merged.elements = Array.isArray(elements)
+        ? elements.map(el => normalizeElement(el)).filter(Boolean)
+        : [];
+    }
+
+    return {
+      id: source.id || generateId('block'),
+      type,
+      name: definition.name,
+      icon: definition.icon,
+      data: merged,
+      meta: {
+        hidden: !!(source.hidden || (source.meta && source.meta.hidden))
+      }
+    };
+  }
+
+  function registerElement(type, definition) {
+    if (!type || !definition) {
+      return null;
+    }
+    elementRegistry[type] = definition;
+    return elementRegistry[type];
+  }
+
+  function registerBlock(type, definition) {
+    if (!type || !definition) {
+      return null;
+    }
+    blockRegistry[type] = definition;
+    return blockRegistry[type];
+  }
+
+  function getElementDefinition(type) {
+    return elementRegistry[type] || null;
+  }
+
+  function getBlockDefinition(type) {
+    return blockRegistry[type] || null;
+  }
+
+  window.SiteBuilder = {
+    elementRegistry,
+    blockRegistry,
+    styles,
+    deepClone,
+    generateId,
+    normalizeElement,
+    createBlockInstance,
+    registerElement,
+    registerBlock,
+    getElementDefinition,
+    getBlockDefinition
+  };
+})();

--- a/sushi-store/client/modules/siteBuilder/elements.js
+++ b/sushi-store/client/modules/siteBuilder/elements.js
@@ -1,0 +1,593 @@
+// Element registry for the site builder
+(function(){
+  const elementRegistry = {
+      heading: {
+        label: 'Заголовок',
+        icon: 'fa-solid fa-heading',
+        defaultData: () => ({
+          text: 'Новый заголовок',
+          level: 'h2',
+          fontSize: 'text-3xl',
+          color: '#111827',
+          align: 'left',
+          marginTop: '0px',
+          marginBottom: '16px',
+          fontFamily: '',
+          fontWeight: '700',
+          lineHeight: '1.2',
+          letterSpacing: '0px',
+          textTransform: 'none',
+          backgroundColor: '',
+          paddingX: '0px',
+          paddingY: '0px',
+          borderRadius: '0px',
+          textShadow: '',
+          positionMode: 'flow',
+          positionX: '0px',
+          positionY: '0px',
+          zIndex: '10',
+          maxWidth: '640px'
+        }),
+        fields: [
+          { key: 'text', label: 'Текст', type: 'text', placeholder: 'Введите заголовок' },
+          {
+            key: 'level',
+            label: 'Уровень',
+            type: 'select',
+            options: [
+              { value: 'h1', label: 'H1' },
+              { value: 'h2', label: 'H2' },
+              { value: 'h3', label: 'H3' }
+            ]
+          },
+          {
+            key: 'fontSize',
+            label: 'Размер',
+            type: 'select',
+            options: [
+              { value: 'text-2xl', label: 'Крупный (2xl)' },
+              { value: 'text-3xl', label: 'Очень крупный (3xl)' },
+              { value: 'text-4xl', label: 'Заголовок (4xl)' }
+            ]
+          },
+          {
+            key: 'fontWeight',
+            label: 'Начертание',
+            type: 'select',
+            options: [
+              { value: '400', label: 'Обычный' },
+              { value: '500', label: 'Средний' },
+              { value: '600', label: 'Полужирный' },
+              { value: '700', label: 'Жирный' },
+              { value: '800', label: 'Экстра жирный' }
+            ]
+          },
+          { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Manrope"' },
+          { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.2' },
+          { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
+          {
+            key: 'textTransform',
+            label: 'Регистр',
+            type: 'select',
+            options: [
+              { value: 'none', label: 'Обычный' },
+              { value: 'uppercase', label: 'Верхний' },
+              { value: 'lowercase', label: 'Нижний' },
+              { value: 'capitalize', label: 'Каждое слово' }
+            ]
+          },
+          {
+            key: 'color',
+            label: 'Цвет текста',
+            type: 'color'
+          },
+          {
+            key: 'align',
+            label: 'Выравнивание',
+            type: 'select',
+            options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ]
+          },
+          { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
+          { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' },
+          { key: 'backgroundColor', label: 'Фон текста', type: 'color' },
+          { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '0px' },
+          { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '0px' },
+          { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '0px' },
+          { key: 'textShadow', label: 'Тень текста', type: 'text', placeholder: '0 10px 30px rgba(15,23,42,0.35)' },
+          {
+            key: 'positionMode',
+            label: 'Расположение',
+            type: 'select',
+            options: [
+              { value: 'flow', label: 'В потоке' },
+              { value: 'free', label: 'Свободное' }
+            ]
+          },
+          { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+          { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+          { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '10' },
+          { key: 'maxWidth', label: 'Макс. ширина', type: 'text', placeholder: '640px' }
+        ]
+      },
+      subheading: {
+        label: 'Подзаголовок',
+        icon: 'fa-solid fa-text-height',
+        defaultData: () => ({
+          text: 'Новый подзаголовок',
+          fontSize: 'text-xl',
+          color: '#f97316',
+          align: 'left',
+          marginTop: '0px',
+          marginBottom: '12px',
+          fontFamily: '',
+          fontWeight: '600',
+          lineHeight: '1.4',
+          letterSpacing: '0px',
+          textTransform: 'none',
+          backgroundColor: '',
+          paddingX: '0px',
+          paddingY: '0px',
+          borderRadius: '0px',
+          textShadow: '',
+          positionMode: 'flow',
+          positionX: '0px',
+          positionY: '0px',
+          zIndex: '10',
+          maxWidth: '640px'
+        }),
+        fields: [
+          { key: 'text', label: 'Текст', type: 'text', placeholder: 'Введите подзаголовок' },
+          {
+            key: 'fontSize',
+            label: 'Размер',
+            type: 'select',
+            options: [
+              { value: 'text-lg', label: 'Крупный' },
+              { value: 'text-xl', label: 'Очень крупный' },
+              { value: 'text-2xl', label: 'Заголовочный' }
+            ]
+          },
+          {
+            key: 'fontWeight',
+            label: 'Начертание',
+            type: 'select',
+            options: [
+              { value: '400', label: 'Обычный' },
+              { value: '500', label: 'Средний' },
+              { value: '600', label: 'Полужирный' },
+              { value: '700', label: 'Жирный' }
+            ]
+          },
+          { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Inter"' },
+          { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.4' },
+          { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
+          {
+            key: 'textTransform',
+            label: 'Регистр',
+            type: 'select',
+            options: [
+              { value: 'none', label: 'Обычный' },
+              { value: 'uppercase', label: 'Верхний' },
+              { value: 'lowercase', label: 'Нижний' },
+              { value: 'capitalize', label: 'Каждое слово' }
+            ]
+          },
+          {
+            key: 'color',
+            label: 'Цвет текста',
+            type: 'color'
+          },
+          {
+            key: 'align',
+            label: 'Выравнивание',
+            type: 'select',
+            options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ]
+          },
+          { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
+          { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '12px' },
+          { key: 'backgroundColor', label: 'Фон текста', type: 'color' },
+          { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '0px' },
+          { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '0px' },
+          { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '0px' },
+          { key: 'textShadow', label: 'Тень текста', type: 'text', placeholder: '0 6px 20px rgba(15,23,42,0.25)' },
+          {
+            key: 'positionMode',
+            label: 'Расположение',
+            type: 'select',
+            options: [
+              { value: 'flow', label: 'В потоке' },
+              { value: 'free', label: 'Свободное' }
+            ]
+          },
+          { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+          { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+          { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '10' },
+          { key: 'maxWidth', label: 'Макс. ширина', type: 'text', placeholder: '640px' }
+        ]
+      },
+      paragraph: {
+        label: 'Текст',
+        icon: 'fa-solid fa-paragraph',
+        defaultData: () => ({
+          text: 'Добавьте описание секции или товара',
+          fontSize: 'text-base',
+          color: '#4b5563',
+          align: 'left',
+          marginTop: '0px',
+          marginBottom: '16px',
+          fontFamily: '',
+          fontWeight: '400',
+          lineHeight: '1.6',
+          letterSpacing: '0px',
+          textTransform: 'none',
+          maxWidth: '640px',
+          backgroundColor: '',
+          paddingX: '0px',
+          paddingY: '0px',
+          borderRadius: '0px',
+          textShadow: '',
+          positionMode: 'flow',
+          positionX: '0px',
+          positionY: '0px',
+          zIndex: '10'
+        }),
+        fields: [
+          { key: 'text', label: 'Текст', type: 'textarea', rows: 3, placeholder: 'Расскажите подробнее' },
+          {
+            key: 'fontSize',
+            label: 'Размер',
+            type: 'select',
+            options: [
+              { value: 'text-sm', label: 'Маленький' },
+              { value: 'text-base', label: 'Стандартный' },
+              { value: 'text-lg', label: 'Крупный' }
+            ]
+          },
+          {
+            key: 'fontWeight',
+            label: 'Начертание',
+            type: 'select',
+            options: [
+              { value: '300', label: 'Светлый' },
+              { value: '400', label: 'Обычный' },
+              { value: '500', label: 'Средний' },
+              { value: '600', label: 'Полужирный' }
+            ]
+          },
+          { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Rubik"' },
+          { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.6' },
+          { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
+          {
+            key: 'textTransform',
+            label: 'Регистр',
+            type: 'select',
+            options: [
+              { value: 'none', label: 'Обычный' },
+              { value: 'uppercase', label: 'Верхний' },
+              { value: 'lowercase', label: 'Нижний' },
+              { value: 'capitalize', label: 'Каждое слово' }
+            ]
+          },
+          { key: 'maxWidth', label: 'Максимальная ширина', type: 'text', placeholder: '640px' },
+          {
+            key: 'color',
+            label: 'Цвет текста',
+            type: 'color'
+          },
+          {
+            key: 'align',
+            label: 'Выравнивание',
+            type: 'select',
+            options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ]
+          },
+          { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
+          { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' },
+          { key: 'backgroundColor', label: 'Фон текста', type: 'color' },
+          { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '0px' },
+          { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '0px' },
+          { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '0px' },
+          { key: 'textShadow', label: 'Тень текста', type: 'text', placeholder: '0 4px 16px rgba(15,23,42,0.15)' },
+          {
+            key: 'positionMode',
+            label: 'Расположение',
+            type: 'select',
+            options: [
+              { value: 'flow', label: 'В потоке' },
+              { value: 'free', label: 'Свободное' }
+            ]
+          },
+          { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+          { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+          { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '10' }
+        ]
+      },
+      button: {
+        label: 'Кнопка',
+        icon: 'fa-solid fa-hand-pointer',
+        defaultData: () => ({
+          text: 'Новая кнопка',
+          style: 'primary',
+          action: 'scrollMenu',
+          href: '',
+          align: 'left',
+          marginTop: '0px',
+          marginBottom: '0px',
+          backgroundColor: '#ffffff',
+          textColor: '#dc2626',
+          hoverBackgroundColor: '#f3f4f6',
+          hoverTextColor: '#b91c1c',
+          borderRadius: '9999px',
+          borderWidth: '0px',
+          borderColor: '#ffffff',
+          paddingX: '28px',
+          paddingY: '14px',
+          fontSize: '16px',
+          fontFamily: '',
+          fontWeight: '600',
+          boxShadow: '0 15px 40px rgba(255,255,255,0.18)',
+          positionMode: 'flow',
+          positionX: '0px',
+          positionY: '0px',
+          zIndex: '20',
+          width: ''
+        }),
+        fields: [
+          { key: 'text', label: 'Текст кнопки', type: 'text', placeholder: 'Например, Заказать' },
+          {
+            key: 'style',
+            label: 'Стиль',
+            type: 'select',
+            options: [
+              { value: 'primary', label: 'Заливка' },
+              { value: 'secondary', label: 'Контур' }
+            ]
+          },
+          {
+            key: 'action',
+            label: 'Действие',
+            type: 'select',
+            options: [
+              { value: 'scrollMenu', label: 'Прокрутка к меню' },
+              { value: 'openCart', label: 'Открыть корзину' },
+              { value: 'link', label: 'Ссылка' }
+            ]
+          },
+          { key: 'href', label: 'Ссылка', type: 'text', placeholder: 'https://...' },
+          { key: 'fontSize', label: 'Размер шрифта (px)', type: 'text', placeholder: '16px' },
+          { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Nunito"' },
+          {
+            key: 'fontWeight',
+            label: 'Начертание',
+            type: 'select',
+            options: [
+              { value: '500', label: 'Средний' },
+              { value: '600', label: 'Полужирный' },
+              { value: '700', label: 'Жирный' }
+            ]
+          },
+          {
+            key: 'align',
+            label: 'Выравнивание',
+            type: 'select',
+            options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ]
+          },
+          { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
+          { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '0px' },
+          { key: 'backgroundColor', label: 'Цвет фона', type: 'color' },
+          { key: 'textColor', label: 'Цвет текста', type: 'color' },
+          { key: 'hoverBackgroundColor', label: 'Фон при наведении', type: 'color' },
+          { key: 'hoverTextColor', label: 'Текст при наведении', type: 'color' },
+          { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '9999px' },
+          { key: 'borderWidth', label: 'Толщина границы', type: 'text', placeholder: '0px' },
+          { key: 'borderColor', label: 'Цвет границы', type: 'color' },
+          { key: 'paddingX', label: 'Горизонтальные отступы', type: 'text', placeholder: '28px' },
+          { key: 'paddingY', label: 'Вертикальные отступы', type: 'text', placeholder: '14px' },
+          { key: 'boxShadow', label: 'Тень', type: 'text', placeholder: '0 15px 40px rgba(255,255,255,0.18)' },
+          {
+            key: 'positionMode',
+            label: 'Расположение',
+            type: 'select',
+            options: [
+              { value: 'flow', label: 'В потоке' },
+              { value: 'free', label: 'Свободное' }
+            ]
+          },
+          { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+          { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+          { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '20' },
+          { key: 'width', label: 'Ширина', type: 'text', placeholder: 'auto' }
+        ]
+      },
+      image: {
+        label: 'Изображение',
+        icon: 'fa-solid fa-image',
+        defaultData: () => ({
+          src: '',
+          alt: 'Изображение',
+          width: '320px',
+          height: 'auto',
+          align: 'left',
+          borderRadius: '16px',
+          marginTop: '0px',
+          marginBottom: '16px',
+          objectFit: 'cover',
+          boxShadow: '0 25px 60px rgba(15,23,42,0.35)',
+          borderWidth: '0px',
+          borderColor: 'rgba(255,255,255,0.2)',
+          backgroundColor: 'transparent',
+          positionMode: 'flow',
+          positionX: '0px',
+          positionY: '0px',
+          zIndex: '5'
+        }),
+        fields: [
+          { key: 'src', label: 'URL изображения', type: 'text', placeholder: 'https://...' },
+          { key: 'alt', label: 'Alt текст', type: 'text', placeholder: 'Подпись' },
+          { key: 'width', label: 'Ширина', type: 'text', placeholder: '320px' },
+          { key: 'height', label: 'Высота', type: 'text', placeholder: 'auto' },
+          {
+            key: 'align',
+            label: 'Выравнивание',
+            type: 'select',
+            options: [
+              { value: 'left', label: 'Слева' },
+              { value: 'center', label: 'По центру' },
+              { value: 'right', label: 'Справа' }
+            ]
+          },
+          { key: 'borderRadius', label: 'Скругление', type: 'text', placeholder: '16px' },
+          { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
+          { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '16px' },
+          {
+            key: 'objectFit',
+            label: 'Вписывание',
+            type: 'select',
+            options: [
+              { value: 'cover', label: 'Cover' },
+              { value: 'contain', label: 'Contain' },
+              { value: 'fill', label: 'Fill' }
+            ]
+          },
+          { key: 'boxShadow', label: 'Тень', type: 'text', placeholder: '0 25px 60px rgba(15,23,42,0.35)' },
+          { key: 'borderWidth', label: 'Толщина границы', type: 'text', placeholder: '0px' },
+          { key: 'borderColor', label: 'Цвет границы', type: 'color' },
+          { key: 'backgroundColor', label: 'Фон', type: 'color' },
+          {
+            key: 'positionMode',
+            label: 'Расположение',
+            type: 'select',
+            options: [
+              { value: 'flow', label: 'В потоке' },
+              { value: 'free', label: 'Свободное' }
+            ]
+          },
+          { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+          { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+          { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '5' }
+        ]
+      },
+      feature: {
+        label: 'Преимущество',
+        icon: 'fa-solid fa-star',
+        defaultData: () => ({
+          text: 'Новое преимущество',
+          icon: 'fa-solid fa-check',
+          color: '#111827',
+          fontSize: 'text-base',
+          marginTop: '0px',
+          marginBottom: '8px',
+          fontFamily: '',
+          fontWeight: '500',
+          lineHeight: '1.4',
+          letterSpacing: '0px',
+          textTransform: 'none',
+          iconColor: '#f97316',
+          iconBackground: 'rgba(249, 115, 22, 0.12)',
+          iconShape: 'circle',
+          positionMode: 'flow',
+          positionX: '0px',
+          positionY: '0px',
+          zIndex: '15'
+        }),
+        fields: [
+          { key: 'text', label: 'Текст', type: 'text', placeholder: 'Например, Бесплатная доставка' },
+          { key: 'icon', label: 'Иконка FontAwesome', type: 'text', placeholder: 'fa-solid fa-check' },
+          { key: 'fontFamily', label: 'Шрифт', type: 'text', placeholder: 'Например, "Open Sans"' },
+          {
+            key: 'fontWeight',
+            label: 'Начертание',
+            type: 'select',
+            options: [
+              { value: '400', label: 'Обычный' },
+              { value: '500', label: 'Средний' },
+              { value: '600', label: 'Полужирный' }
+            ]
+          },
+          {
+            key: 'color',
+            label: 'Цвет текста',
+            type: 'color'
+          },
+          {
+            key: 'fontSize',
+            label: 'Размер',
+            type: 'select',
+            options: [
+              { value: 'text-sm', label: 'Маленький' },
+              { value: 'text-base', label: 'Стандартный' },
+              { value: 'text-lg', label: 'Крупный' }
+            ]
+          },
+          { key: 'lineHeight', label: 'Межстрочный интервал', type: 'text', placeholder: '1.4' },
+          { key: 'letterSpacing', label: 'Интервал между буквами', type: 'text', placeholder: '0px' },
+          {
+            key: 'textTransform',
+            label: 'Регистр',
+            type: 'select',
+            options: [
+              { value: 'none', label: 'Обычный' },
+              { value: 'uppercase', label: 'Верхний' },
+              { value: 'capitalize', label: 'Каждое слово' }
+            ]
+          },
+          { key: 'iconColor', label: 'Цвет иконки', type: 'color' },
+          { key: 'iconBackground', label: 'Фон иконки', type: 'color' },
+          {
+            key: 'iconShape',
+            label: 'Форма иконки',
+            type: 'select',
+            options: [
+              { value: 'circle', label: 'Круг' },
+              { value: 'rounded', label: 'Скруглённый квадрат' },
+              { value: 'square', label: 'Квадрат' }
+            ]
+          },
+          { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
+          { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '8px' },
+          {
+            key: 'positionMode',
+            label: 'Расположение',
+            type: 'select',
+            options: [
+              { value: 'flow', label: 'В потоке' },
+              { value: 'free', label: 'Свободное' }
+            ]
+          },
+          { key: 'positionX', label: 'Позиция X', type: 'text', placeholder: '0px' },
+          { key: 'positionY', label: 'Позиция Y', type: 'text', placeholder: '0px' },
+          { key: 'zIndex', label: 'Слой (z-index)', type: 'text', placeholder: '15' }
+        ]
+      },
+      spacer: {
+        label: 'Отступ',
+        icon: 'fa-solid fa-ruler-vertical',
+        defaultData: () => ({
+          height: '24px',
+          marginTop: '0px',
+          marginBottom: '0px'
+        }),
+        fields: [
+          { key: 'height', label: 'Высота', type: 'text', placeholder: '24px' },
+          { key: 'marginTop', label: 'Отступ сверху', type: 'text', placeholder: '0px' },
+          { key: 'marginBottom', label: 'Отступ снизу', type: 'text', placeholder: '0px' }
+        ]
+      }
+    };
+  window.SiteBuilderElements = elementRegistry;
+})();

--- a/sushi-store/client/modules/siteBuilder/styles.js
+++ b/sushi-store/client/modules/siteBuilder/styles.js
@@ -1,0 +1,757 @@
+// Shared style helpers for the site builder previews
+(function(){
+      function heroImageProps(element) {
+        const data = element.data || {};
+        return {
+          src: data.src || 'https://images.unsplash.com/photo-1607301405418-780ee5e6dd10',
+          alt: data.alt || 'Изображение',
+          style: {
+            width: asCssSize(data.width, '320px'),
+            height: data.height ? asCssSize(data.height, 'auto') : 'auto',
+            borderRadius: asCssSize(data.borderRadius, '16px'),
+            objectFit: data.objectFit || 'cover',
+            boxShadow: data.boxShadow || '0 25px 60px rgba(15,23,42,0.35)',
+            borderWidth: asCssSize(data.borderWidth, '0px'),
+            borderStyle: 'solid',
+            borderColor: data.borderColor || 'rgba(255,255,255,0.2)',
+            backgroundColor: data.backgroundColor || 'transparent'
+          }
+        };
+      }
+      function sectionBackgroundStyle(data = {}, fallbackColor = '#ffffff') {
+        const style = {
+          backgroundColor: data.backgroundColor || fallbackColor,
+          padding: `${asCssSize(data.sectionPaddingY, '64px')} ${asCssSize(data.sectionPaddingX, '40px')}`,
+          position: 'relative'
+        };
+        const mode = data.backgroundMode || 'solid';
+        if (mode === 'gradient' && data.backgroundGradient) {
+          style.backgroundImage = data.backgroundGradient;
+        } else if (mode === 'image' && data.backgroundImage) {
+          style.backgroundImage = `url(${data.backgroundImage})`;
+          style.backgroundSize = data.backgroundSize || 'cover';
+          style.backgroundPosition = data.backgroundPosition || 'center center';
+          style.backgroundRepeat = data.backgroundRepeat || 'no-repeat';
+        } else {
+          style.backgroundImage = 'none';
+        }
+        if (data.sectionBorderRadius) {
+          style.borderRadius = asCssSize(data.sectionBorderRadius, data.sectionBorderRadius);
+        }
+        if (data.sectionShadow) {
+          style.boxShadow = data.sectionShadow;
+        }
+        return style;
+      }
+      function sectionOverlayStyle(data = {}) {
+        if (!data.overlayColor) {
+          return null;
+        }
+        const style = {
+          background: data.overlayColor,
+          position: 'absolute',
+          inset: '0',
+          pointerEvents: 'none'
+        };
+        if (data.overlayBlur && data.overlayBlur !== '0' && data.overlayBlur !== '0px') {
+          style.backdropFilter = `blur(${asCssSize(data.overlayBlur, data.overlayBlur)})`;
+        }
+        return style;
+      }
+      function blockButtonWrapperStyle(config = {}) {
+        const align = config.buttonAlign || 'center';
+        return { textAlign: align };
+      }
+      function blockButtonClass(config = {}) {
+        const classes = ['inline-flex', 'items-center', 'justify-center', 'font-semibold', 'transition'];
+        if ((config.buttonStyle || 'primary') !== 'link') {
+          classes.push('px-6', 'py-3');
+        }
+        return classes.join(' ');
+      }
+      function blockButtonStyle(config = {}, defaults = {}) {
+        const baseBackground = defaults.background || '#f97316';
+        const style = {
+          border: 'none',
+          gap: '8px',
+          borderRadius: asCssSize(config.buttonBorderRadius, defaults.borderRadius || '999px'),
+          color: config.buttonTextColor || defaults.textColor || '#ffffff',
+          background: config.buttonBackground || baseBackground,
+          boxShadow: config.buttonShadow || defaults.shadow || 'none',
+          padding: config.buttonStyle === 'link' ? '0' : (config.buttonPadding || '12px 28px')
+        };
+        if (config.buttonStyle === 'secondary') {
+          style.background = config.buttonBackground || defaults.secondaryBackground || '#ffffff';
+          style.color = config.buttonTextColor || defaults.secondaryText || '#111827';
+        } else if (config.buttonStyle === 'outline') {
+          const borderColor = config.buttonBackground || baseBackground;
+          style.background = 'transparent';
+          style.color = config.buttonTextColor || borderColor;
+          style.border = `2px solid ${borderColor}`;
+          style.boxShadow = config.buttonShadow || 'none';
+        } else if (config.buttonStyle === 'link') {
+          style.background = 'transparent';
+          style.color = config.buttonTextColor || config.buttonBackground || baseBackground;
+          style.boxShadow = 'none';
+        }
+        return style;
+      }
+      function categoriesSectionStyle(block) {
+        return sectionBackgroundStyle(block?.data || {}, '#f9f4e5');
+      }
+      function categoriesOverlayStyle(block) {
+        return sectionOverlayStyle(block?.data || {});
+      }
+      function categoriesHeaderStyle(block) {
+        const data = block?.data || {};
+        const textAlign = data.textAlign || 'center';
+        return {
+          textAlign,
+          maxWidth: asCssSize(data.descriptionMaxWidth, '720px'),
+          margin: textAlign === 'left' ? '0' : '0 auto'
+        };
+      }
+      function categoriesHeadingStyle(block) {
+        const data = block?.data || {};
+        return {
+          color: data.headingColor || '#111827',
+          fontSize: data.headingFontSize || '40px',
+          fontWeight: data.headingFontWeight || '700',
+          fontFamily: data.headingFontFamily || 'inherit'
+        };
+      }
+      function categoriesSubheadingStyle(block) {
+        const data = block?.data || {};
+        return {
+          color: data.subheadingColor || '#f97316',
+          fontSize: data.subheadingFontSize || '20px',
+          fontWeight: data.subheadingFontWeight || '600'
+        };
+      }
+      function categoriesDescriptionStyle(block) {
+        const data = block?.data || {};
+        return {
+          color: data.descriptionColor || '#4b5563',
+          fontSize: data.descriptionFontSize || '18px'
+        };
+      }
+      function categoriesGridStyle(block) {
+        const data = block?.data || {};
+        const gap = asCssSize(data.cardGap, '24px');
+        const minWidth = asCssSize(data.cardMinWidth, '240px');
+        return {
+          gap,
+          gridTemplateColumns: `repeat(auto-fit, minmax(${minWidth}, 1fr))`
+        };
+      }
+      function categoriesCardStyle(block) {
+        const data = block?.data || {};
+        return {
+          background: data.cardBackground || '#ffffff',
+          color: data.cardTextColor || '#1f2937',
+          padding: data.cardPadding || '28px',
+          borderRadius: asCssSize(data.cardBorderRadius, '24px'),
+          boxShadow: data.cardShadow || '0 20px 45px rgba(15,23,42,0.08)',
+          border: data.cardBorderColor ? `1px solid ${data.cardBorderColor}` : 'none',
+          textAlign: 'center'
+        };
+      }
+      function categoriesIconWrapperStyle(block) {
+        const data = block?.data || {};
+        const size = asCssSize(data.cardIconSize, '80px');
+        let radius = '9999px';
+        if (data.cardIconShape === 'rounded') {
+          radius = '24px';
+        } else if (data.cardIconShape === 'square') {
+          radius = '12px';
+        }
+        return {
+          width: size,
+          height: size,
+          margin: '0 auto',
+          borderRadius: radius,
+          background: data.cardIconBackground || 'rgba(249,115,22,0.12)',
+          color: data.cardIconColor || '#f97316',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '28px'
+        };
+      }
+      function categoriesCardTitleStyle(block) {
+        return { color: block?.data?.cardTextColor || '#1f2937' };
+      }
+      function categoriesCardDescriptionStyle(block) {
+        return { color: block?.data?.cardDescriptionColor || '#6b7280' };
+      }
+      function menuSectionStyle(block) {
+        return sectionBackgroundStyle(block?.data || {}, '#fff7ed');
+      }
+      function menuOverlayStyle(block) {
+        return sectionOverlayStyle(block?.data || {});
+      }
+      function menuHeaderStyle(block) {
+        const data = block?.data || {};
+        const textAlign = data.textAlign || 'center';
+        return {
+          textAlign,
+          maxWidth: asCssSize(data.descriptionMaxWidth, '640px'),
+          margin: textAlign === 'left' ? '0' : '0 auto'
+        };
+      }
+      function menuHeadingStyle(block) {
+        const data = block?.data || {};
+        return {
+          color: data.headingColor || '#111827',
+          fontSize: data.headingFontSize || '36px',
+          fontWeight: data.headingFontWeight || '700',
+          fontFamily: data.headingFontFamily || 'inherit'
+        };
+      }
+      function menuDescriptionStyle(block) {
+        const data = block?.data || {};
+        return {
+          color: data.descriptionColor || '#4b5563',
+          fontSize: data.descriptionFontSize || '18px'
+        };
+      }
+      function menuFilterSurfaceStyle(block) {
+        const data = block?.data || {};
+        return {
+          background: data.filtersBackground || 'rgba(255,255,255,0.7)',
+          color: data.filtersTextColor || '#1f2937',
+          boxShadow: data.filtersShadow || 'none',
+          borderRadius: '16px',
+          padding: '12px 20px'
+        };
+      }
+      function menuTabsWrapperStyle(block) {
+        const align = block?.data?.textAlign || 'center';
+        let justify = 'center';
+        if (align === 'left') justify = 'flex-start';
+        if (align === 'right') justify = 'flex-end';
+        return { justifyContent: justify };
+      }
+      function menuActiveTabStyle(block) {
+        const data = block?.data || {};
+        return {
+          background: data.tagBackground || 'rgba(249,115,22,0.12)',
+          color: data.tagTextColor || '#f97316'
+        };
+      }
+      function menuTabStyle(block) {
+        const data = block?.data || {};
+        return {
+          background: 'rgba(255,255,255,0.6)',
+          color: (data.filtersTextColor || '#1f2937') + 'cc',
+          border: '1px solid rgba(255,255,255,0.4)'
+        };
+      }
+      function menuGridStyle(block) {
+        const data = block?.data || {};
+        const columns = clampNumber(Number(data.cardsPerRow) || 3, 1, 4);
+        const minWidth = asCssSize(data.cardMinWidth, '260px');
+        return {
+          gap: '24px',
+          gridTemplateColumns: `repeat(${columns}, minmax(${minWidth}, 1fr))`
+        };
+      }
+      function menuCardStyle(block) {
+        const data = block?.data || {};
+        return {
+          background: data.cardBackground || '#ffffff',
+          color: data.cardTextColor || '#1f2937',
+          padding: '20px',
+          borderRadius: asCssSize(data.cardBorderRadius, '24px'),
+          boxShadow: data.cardShadow || '0 18px 40px rgba(15,23,42,0.08)',
+          border: data.cardBorderColor ? `1px solid ${data.cardBorderColor}` : 'none'
+        };
+      }
+      function menuCardImageStyle(block) {
+        const data = block?.data || {};
+        return {
+          height: asCssSize(data.cardImageHeight, '180px'),
+          borderRadius: '18px',
+          overflow: 'hidden',
+          background: 'rgba(148,163,184,0.2)'
+        };
+      }
+      function menuCardTitleStyle(block) {
+        return { color: block?.data?.cardTextColor || '#1f2937' };
+      }
+      function menuCardDescriptionStyle(block) {
+        return { color: block?.data?.cardDescriptionColor || '#6b7280' };
+      }
+      function menuPriceStyle(block) {
+        return { color: block?.data?.priceColor || '#f97316', fontWeight: '600' };
+      }
+      function menuTagStyle(block) {
+        const data = block?.data || {};
+        return {
+          background: data.tagBackground || 'rgba(249,115,22,0.12)',
+          color: data.tagTextColor || '#f97316'
+        };
+      }
+      function deliverySectionStyle(block) {
+        return sectionBackgroundStyle(block?.data || {}, '#fff7ed');
+      }
+      function deliveryOverlayStyle(block) {
+        return sectionOverlayStyle(block?.data || {});
+      }
+      function deliveryTextColumnStyle(block) {
+        return { color: block?.data?.textColor || '#4b5563' };
+      }
+      function deliveryHeadingStyle(block) {
+        const data = block?.data || {};
+        return {
+          color: data.headingColor || '#111827',
+          fontSize: data.headingFontSize || '36px',
+          fontWeight: data.headingFontWeight || '700',
+          fontFamily: data.headingFontFamily || 'inherit'
+        };
+      }
+      function deliveryDescriptionStyle(block) {
+        return { color: block?.data?.textColor || '#4b5563' };
+      }
+      function deliveryFeatureIconStyle(block) {
+        const data = block?.data || {};
+        const bg = data.featureIconBackground || '#f97316';
+        let radius = '9999px';
+        if (data.featureIconShape === 'rounded') {
+          radius = '18px';
+        } else if (data.featureIconShape === 'square') {
+          radius = '8px';
+        }
+        return {
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '28px',
+          height: '28px',
+          borderRadius: radius,
+          background: bg,
+          color: data.featureIconColor || '#ffffff',
+          fontSize: '12px'
+        };
+      }
+      function deliveryFeatureTextStyle(block) {
+        return { color: block?.data?.featureTextColor || '#1f2937', fontSize: '14px' };
+      }
+      function deliveryContactsStyle(block) {
+        return { color: block?.data?.contactTextColor || '#4b5563' };
+      }
+      function deliveryTrackingCardStyle(block) {
+        const data = block?.data || {};
+        return {
+          background: data.cardBackground || '#ffffff',
+          borderRadius: asCssSize(data.cardBorderRadius, '24px'),
+          boxShadow: data.cardShadow || '0 20px 50px rgba(15,23,42,0.1)',
+          overflow: 'hidden'
+        };
+      }
+      function deliveryTrackingBarStyle(block) {
+        const data = block?.data || {};
+        const base = data.featureIconBackground || '#f97316';
+        return {
+          height: '48px',
+          background: `linear-gradient(90deg, ${base}, rgba(239,68,68,0.85))`
+        };
+      }
+      function deliveryTrackingTitleStyle(block) {
+        return { color: block?.data?.cardTextColor || '#1f2937' };
+      }
+      function deliveryTrackingDescriptionStyle(block) {
+        return { color: block?.data?.contactTextColor || '#6b7280' };
+      }
+      function deliveryTrackingProgressStyle(block) {
+        const data = block?.data || {};
+        const percent = clampNumber(parseCssNumber(data.trackingProgress, 75), 0, 100);
+        return {
+          width: `${percent}%`,
+          background: data.featureIconBackground || '#f97316'
+        };
+      }
+      function reviewsSectionStyle(block) {
+        return sectionBackgroundStyle(block?.data || {}, '#fff7ed');
+      }
+      function reviewsOverlayStyle(block) {
+        return sectionOverlayStyle(block?.data || {});
+      }
+      function reviewsHeaderStyle(block) {
+        const data = block?.data || {};
+        const textAlign = data.textAlign || 'center';
+        return {
+          textAlign,
+          maxWidth: asCssSize(data.descriptionMaxWidth, '640px'),
+          margin: textAlign === 'left' ? '0' : '0 auto'
+        };
+      }
+      function reviewsHeadingStyle(block) {
+        const data = block?.data || {};
+        return {
+          color: data.headingColor || '#111827',
+          fontSize: data.headingFontSize || '36px',
+          fontWeight: data.headingFontWeight || '700',
+          fontFamily: data.headingFontFamily || 'inherit'
+        };
+      }
+      function reviewsDescriptionStyle(block) {
+        return { color: block?.data?.descriptionColor || '#4b5563', fontSize: block?.data?.descriptionFontSize || '18px' };
+      }
+      function reviewsGridStyle(block) {
+        const data = block?.data || {};
+        const cols = clampNumber(Number(data.columns) || 3, 1, 4);
+        return {
+          gap: '24px',
+          gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`
+        };
+      }
+      function reviewsCardStyle(block) {
+        const data = block?.data || {};
+        return {
+          background: data.cardBackground || '#ffffff',
+          color: data.cardTextColor || '#1f2937',
+          padding: '24px',
+          borderRadius: asCssSize(data.cardBorderRadius, '24px'),
+          boxShadow: data.cardShadow || '0 16px 40px rgba(15,23,42,0.08)',
+          border: data.cardBorderColor ? `1px solid ${data.cardBorderColor}` : 'none'
+        };
+      }
+      function reviewsAvatarStyle(block) {
+        const data = block?.data || {};
+        const background = data.avatarBackground || '#f97316';
+        let radius = '9999px';
+        if (data.avatarShape === 'rounded') {
+          radius = '20px';
+        } else if (data.avatarShape === 'square') {
+          radius = '12px';
+        }
+        return {
+          width: '48px',
+          height: '48px',
+          borderRadius: radius,
+          background,
+          color: '#ffffff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: '600'
+        };
+      }
+      function reviewsCardTitleStyle(block) {
+        return { color: block?.data?.cardTextColor || '#1f2937' };
+      }
+      function reviewsCardSubtitleStyle(block) {
+        return { color: (block?.data?.cardTextColor || '#1f2937') + '99' };
+      }
+      function reviewsRatingStyle(block) {
+        return { color: block?.data?.ratingColor || '#facc15' };
+      }
+      function reviewsQuoteStyle(block) {
+        return { color: block?.data?.cardQuoteColor || '#4b5563' };
+      }
+      function mapSectionStyle(block) {
+        return sectionBackgroundStyle(block?.data || {}, '#ffffff');
+      }
+      function mapOverlayStyle(block) {
+        return sectionOverlayStyle(block?.data || {});
+      }
+      function mapFrameStyle(block) {
+        const data = block?.data || {};
+        return {
+          height: asCssSize(data.mapHeight, '380px'),
+          borderRadius: asCssSize(data.mapBorderRadius, '24px'),
+          boxShadow: data.mapShadow || '0 20px 45px rgba(15,23,42,0.08)',
+          overflow: 'hidden'
+        };
+      }
+      function mapIframeStyle(block) {
+        return {
+          width: '100%',
+          height: '100%',
+          border: '0'
+        };
+      }
+      function mapInfoCardStyle(block) {
+        const data = block?.data || {};
+        return {
+          background: data.cardBackground || 'rgba(255,255,255,0.92)',
+          color: data.cardTextColor || '#1f2937',
+          borderRadius: asCssSize(data.cardBorderRadius, '24px'),
+          boxShadow: data.cardShadow || '0 18px 40px rgba(15,23,42,0.08)',
+          padding: '24px'
+        };
+      }
+      function mapHeadingStyle(block) {
+        const data = block?.data || {};
+        return {
+          color: data.headingColor || '#111827',
+          fontSize: data.headingFontSize || '32px',
+          fontWeight: data.headingFontWeight || '700',
+          fontFamily: data.headingFontFamily || 'inherit'
+        };
+      }
+      function mapDescriptionStyle(block) {
+        return { color: block?.data?.descriptionColor || '#4b5563', fontSize: block?.data?.descriptionFontSize || '18px' };
+      }
+      function mapContactRowStyle(block) {
+        const data = block?.data || {};
+        return {
+          color: data.contactTextColor || '#4b5563',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px'
+        };
+      }
+      function mapContactIconStyle(block) {
+        return { color: block?.data?.contactIconColor || '#f97316' };
+      }
+      function heroWrapperStyle(block) {
+        const data = block.data || {};
+        const layout = data.layout || 'split';
+        const heightValue = layout === 'freeform'
+          ? asCssSize(data.freeformHeight || data.minHeight, '640px')
+          : asCssSize(data.minHeight, '560px');
+        return {
+          minHeight: heightValue,
+          padding: `${asCssSize(data.contentPaddingY, '120px')} ${asCssSize(data.contentPaddingX, '96px')}`,
+          position: 'relative'
+        };
+      }
+      function heroBackgroundStyle(block) {
+        const data = block.data || {};
+        const image = data.backgroundImage ? `url(${data.backgroundImage})` : 'none';
+        return {
+          backgroundImage: image,
+          backgroundPosition: data.backgroundPosition || 'center center',
+          backgroundSize: data.backgroundSize || 'cover',
+          backgroundRepeat: data.backgroundRepeat || 'no-repeat'
+        };
+      }
+      function heroOverlayStyle(block) {
+        const data = block.data || {};
+        const styles = {
+          background: data.overlayColor || 'rgba(17, 24, 39, 0.55)'
+        };
+        const blurValue = parseFloat(data.overlayBlur);
+        if (!Number.isNaN(blurValue) && blurValue > 0) {
+          styles.backdropFilter = `blur(${blurValue}px)`;
+        }
+        return styles;
+      }
+      function heroContainerClasses(block) {
+        const data = block.data || {};
+        const layout = data.layout || 'split';
+        if (layout === 'split') {
+          const classes = ['relative', 'grid', 'items-center', 'w-full'];
+          if (data.showRightImage) {
+            classes.push('lg:grid-cols-2');
+          } else {
+            classes.push('grid-cols-1');
+          }
+          return classes.join(' ');
+        }
+        if (layout === 'freeform') {
+          return 'relative flex flex-col w-full';
+        }
+        return 'relative flex flex-col items-center w-full';
+      }
+      function heroContainerStyle(block) {
+        const data = block.data || {};
+        const layout = data.layout || 'split';
+        if (layout === 'freeform') {
+          return {
+            gap: '0px',
+            position: 'relative',
+            width: '100%'
+          };
+        }
+        return {
+          gap: asCssSize(data.contentGap, '40px')
+        };
+      }
+      function heroContentColumnClasses(block) {
+        const data = block.data || {};
+        const layout = data.layout || 'split';
+        if (layout === 'freeform') {
+          return 'relative w-full min-h-[320px]';
+        }
+        const classes = ['space-y-4', 'w-full'];
+        if (layout === 'split') {
+          classes.push('text-left');
+          if (data.imageSide === 'left' && data.showRightImage) {
+            classes.push('lg:order-2');
+          }
+        } else {
+          classes.push('mx-auto', 'text-center');
+          if (layout === 'spotlight') {
+            classes.push('order-2');
+          }
+        }
+        return classes.join(' ');
+      }
+      function heroContentStyle(block) {
+        const data = block.data || {};
+        const style = {
+          maxWidth: asCssSize(data.contentMaxWidth, '620px'),
+          width: '100%'
+        };
+        if (data.layout === 'freeform') {
+          style.position = 'relative';
+          style.minHeight = asCssSize(data.freeformHeight || data.minHeight, '640px');
+        } else if (data.layout && data.layout !== 'split') {
+          style.marginLeft = 'auto';
+          style.marginRight = 'auto';
+        }
+        return style;
+      }
+      function heroMediaWrapperClasses(block) {
+        const data = block.data || {};
+        if (!data.showRightImage) {
+          return 'hidden';
+        }
+        const layout = data.layout || 'split';
+        if (layout === 'freeform') {
+          return 'hidden';
+        }
+        if (layout === 'split') {
+          const classes = ['hidden', 'lg:flex', 'items-center', 'justify-center'];
+          if (data.imageSide === 'left') {
+            classes.push('lg:order-1');
+          }
+          return classes.join(' ');
+        }
+        if (layout === 'spotlight') {
+          return 'flex justify-center order-1 w-full mb-10';
+        }
+        return 'flex justify-center w-full mt-10';
+      }
+      function heroFeatureIconWrapperStyle(element) {
+        const data = element.data || {};
+        let borderRadius = '9999px';
+        if (data.iconShape === 'square') {
+          borderRadius = '12px';
+        } else if (data.iconShape === 'rounded') {
+          borderRadius = '18px';
+        }
+        return {
+          backgroundColor: data.iconBackground || 'rgba(249, 115, 22, 0.12)',
+          color: data.iconColor || '#f97316',
+          borderRadius
+        };
+      }
+      function asCssSize(value, fallback) {
+        if (value === null || value === undefined) {
+          return fallback;
+        }
+        const trimmed = String(value).trim();
+        if (!trimmed) {
+          return fallback;
+        }
+        if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+          return `${trimmed}px`;
+        }
+        return trimmed;
+      }
+      function parseCssNumber(value, fallback = 0) {
+        if (value === null || value === undefined) {
+          return fallback;
+        }
+        const match = String(value).match(/-?\d+(\.\d+)?/);
+        return match ? Number(match[0]) : fallback;
+      }
+      function clampNumber(value, min, max) {
+        if (!Number.isFinite(value)) {
+          return min;
+        }
+        if (value < min) {
+          return min;
+        }
+        if (value > max) {
+          return max;
+        }
+        return value;
+      }
+
+  window.SiteBuilderStyles = {
+    heroImageProps,
+    sectionBackgroundStyle,
+    sectionOverlayStyle,
+    blockButtonWrapperStyle,
+    blockButtonClass,
+    blockButtonStyle,
+    categoriesSectionStyle,
+    categoriesOverlayStyle,
+    categoriesHeaderStyle,
+    categoriesHeadingStyle,
+    categoriesSubheadingStyle,
+    categoriesDescriptionStyle,
+    categoriesGridStyle,
+    categoriesCardStyle,
+    categoriesIconWrapperStyle,
+    categoriesCardTitleStyle,
+    categoriesCardDescriptionStyle,
+    menuSectionStyle,
+    menuOverlayStyle,
+    menuHeaderStyle,
+    menuHeadingStyle,
+    menuDescriptionStyle,
+    menuFilterSurfaceStyle,
+    menuTabsWrapperStyle,
+    menuActiveTabStyle,
+    menuTabStyle,
+    menuGridStyle,
+    menuCardStyle,
+    menuCardImageStyle,
+    menuCardTitleStyle,
+    menuCardDescriptionStyle,
+    menuPriceStyle,
+    menuTagStyle,
+    deliverySectionStyle,
+    deliveryOverlayStyle,
+    deliveryTextColumnStyle,
+    deliveryHeadingStyle,
+    deliveryDescriptionStyle,
+    deliveryFeatureIconStyle,
+    deliveryFeatureTextStyle,
+    deliveryContactsStyle,
+    deliveryTrackingCardStyle,
+    deliveryTrackingBarStyle,
+    deliveryTrackingTitleStyle,
+    deliveryTrackingDescriptionStyle,
+    deliveryTrackingProgressStyle,
+    reviewsSectionStyle,
+    reviewsOverlayStyle,
+    reviewsHeaderStyle,
+    reviewsHeadingStyle,
+    reviewsDescriptionStyle,
+    reviewsGridStyle,
+    reviewsCardStyle,
+    reviewsAvatarStyle,
+    reviewsCardTitleStyle,
+    reviewsCardSubtitleStyle,
+    reviewsRatingStyle,
+    reviewsQuoteStyle,
+    mapSectionStyle,
+    mapOverlayStyle,
+    mapFrameStyle,
+    mapIframeStyle,
+    mapInfoCardStyle,
+    mapHeadingStyle,
+    mapDescriptionStyle,
+    mapContactRowStyle,
+    mapContactIconStyle,
+    heroWrapperStyle,
+    heroBackgroundStyle,
+    heroOverlayStyle,
+    heroContainerClasses,
+    heroContainerStyle,
+    heroContentColumnClasses,
+    heroContentStyle,
+    heroMediaWrapperClasses,
+    heroFeatureIconWrapperStyle,
+    asCssSize,
+    parseCssNumber,
+    clampNumber
+  };
+})();


### PR DESCRIPTION
## Summary
- default the canvas to full-page mode, add selection overlays, and track block/element refs for accurate highlighting
- expand hero block controls with layout, spacing, typography, and media options plus helper utilities for consistent CSS values
- refresh hero preview rendering to honor new options and support richer feature/button customization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da340ea8988330998c977f914c9c58